### PR TITLE
fix: handle empty maps in yaml _missing_translations

### DIFF
--- a/slang/lib/runner/apply.dart
+++ b/slang/lib/runner/apply.dart
@@ -173,8 +173,12 @@ Map<I18nLocale, Map<String, dynamic>> _readMissingTranslations({
         }
 
         final locale = I18nLocale.fromString(entry.key);
-
         if (targetLocales != null && !targetLocales.contains(locale)) {
+          continue;
+        }
+
+        if (entry.value == null) {
+          // in yaml, empty maps are parsed as null
           continue;
         }
 


### PR DESCRIPTION
Fixes #151 