### PR TITLE
fix: Handle negative values properly in Swedish.

### DIFF
--- a/slang/lib/api/plural_resolver_map.dart
+++ b/slang/lib/api/plural_resolver_map.dart
@@ -171,7 +171,7 @@ final Map<String, _Resolvers> _resolverMap = {
       if (n == 0) {
         return zero ?? other!;
       }
-      if (n == 1) {
+      if (n == 1 || n == -1) {
         return one ?? other!;
       }
       return other!;


### PR DESCRIPTION
Minus one should be spoken the same as positive one in Swedish. This fix handles this.