### PR TITLE
Remove unnecessary optimisation for build_runner builder

### DIFF
--- a/slang_build_runner/lib/slang_build_runner.dart
+++ b/slang_build_runner/lib/slang_build_runner.dart
@@ -24,18 +24,12 @@ Builder i18nBuilder(BuilderOptions options) {
 class I18nBuilder implements Builder {
   final RawConfig config;
   final String outputFilePattern;
-  bool _generated = false;
 
   I18nBuilder({required this.config})
       : this.outputFilePattern = config.outputFileName.getFileExtension();
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    // only generate once
-    if (_generated) return;
-
-    _generated = true;
-
     final Glob findAssetsPattern = config.inputDirectory != null
         ? Glob('**${config.inputDirectory}/**${config.inputFilePattern}')
         : Glob('**${config.inputFilePattern}');


### PR DESCRIPTION
Fixes #90

build_runner seems to do a good-enough job of detecting whether the source files have changed by itself -- there's no need to do anything extra. I do not see `build` being triggered redundantly on first build, or getting triggered with unchanged source files.

This change will allow using `build_runner` to rebuild from a non-clean state, including in the dev environment.