### PR TITLE
Make it possible to use a custom name for the output class that accesses the translations

### DIFF
--- a/slang/README.md
+++ b/slang/README.md
@@ -440,6 +440,7 @@ targets:
 | `obfuscation`/`enabled`             | `Boolean`                          | enable obfuscation [(i)](#-obfuscation)                      | `false`       |
 | `obfuscation`/`secret`              | `String`                           | obfuscation secret (random if null) [(i)](#-obfuscation)     | `null`        |
 | `imports`                           | `List<String>`                     | generate import statements                                   | `[]`          |
+| `class_name`                        | `String`                           | name of the translations class                               | `Translations`|
 
 ## Main Features
 

--- a/slang/lib/builder/builder/generate_config_builder.dart
+++ b/slang/lib/builder/builder/generate_config_builder.dart
@@ -37,6 +37,7 @@ class GenerateConfigBuilder {
       interface: interfaces,
       obfuscation: config.obfuscation,
       imports: config.imports,
+      className: config.className,
     );
   }
 }

--- a/slang/lib/builder/builder/raw_config_builder.dart
+++ b/slang/lib/builder/builder/raw_config_builder.dart
@@ -107,6 +107,7 @@ class RawConfigBuilder {
               ?.toObfuscationConfig() ??
           RawConfig.defaultObfuscationConfig,
       imports: map['imports']?.cast<String>() ?? RawConfig.defaultImports,
+      className: map['class_name'] ?? RawConfig.defaultClassName,
       rawMap: map,
     );
   }

--- a/slang/lib/builder/generator/generate_header.dart
+++ b/slang/lib/builder/generator/generate_header.dart
@@ -302,7 +302,7 @@ void _generateTranslationGetter({
   required GenerateConfig config,
   required String baseClassName,
 }) {
-  const String translationsClass = 'Translations';
+  final String translationsClass = config.className;
   final String translateVar = config.translateVariable;
   final String enumName = config.enumName;
 

--- a/slang/lib/builder/model/generate_config.dart
+++ b/slang/lib/builder/model/generate_config.dart
@@ -26,6 +26,7 @@ class GenerateConfig {
   final List<Interface> interface; // may include more than in build config
   final ObfuscationConfig obfuscation;
   final List<String> imports;
+  final String className;
 
   GenerateConfig({
     required this.buildConfig,
@@ -46,5 +47,6 @@ class GenerateConfig {
     required this.interface,
     required this.obfuscation,
     required this.imports,
+    required this.className,
   });
 }

--- a/slang/lib/builder/model/raw_config.dart
+++ b/slang/lib/builder/model/raw_config.dart
@@ -38,6 +38,7 @@ class RawConfig {
   static final ObfuscationConfig defaultObfuscationConfig =
       ObfuscationConfig.disabled();
   static const List<String> defaultImports = <String>[];
+  static const String defaultClassName = 'Translations';
 
   final FileType fileType;
   final I18nLocale baseLocale;
@@ -69,6 +70,7 @@ class RawConfig {
   final List<InterfaceConfig> interfaces;
   final ObfuscationConfig obfuscation;
   final List<String> imports;
+  final String className;
 
   /// Used by external tools to access the raw config. (e.g. slang_gpt)
   final Map<String, dynamic> rawMap;
@@ -103,6 +105,7 @@ class RawConfig {
     required this.interfaces,
     required this.obfuscation,
     required this.imports,
+    required this.className,
     required this.rawMap,
   }) : fileType = _determineFileType(inputFilePattern);
 
@@ -157,6 +160,7 @@ class RawConfig {
       interfaces: interfaces ?? this.interfaces,
       obfuscation: obfuscation ?? this.obfuscation,
       imports: imports,
+      className: className,
       rawMap: rawMap,
     );
   }
@@ -268,6 +272,7 @@ class RawConfig {
     interfaces: RawConfig.defaultInterfaces,
     obfuscation: RawConfig.defaultObfuscationConfig,
     imports: RawConfig.defaultImports,
+    className: RawConfig.defaultClassName,
     rawMap: {},
   );
 }


### PR DESCRIPTION
Right now to access the translations you access the "Translations" class, but with this PR it is possible the name the class whatever you want, like in the flutter_localizations package.

This makes it easier to use a shorter name.