### PR TITLE
Added linter ignore and coverage ignore for multiple file generation

### DIFF
--- a/slang/lib/builder/generator/generate_translation_map.dart
+++ b/slang/lib/builder/generator/generate_translation_map.dart
@@ -8,7 +8,15 @@ String generateTranslationMap(
 
   if (config.outputFormat == OutputFormat.multipleFiles) {
     // this is a part file
-    buffer.writeln('part of \'${config.outputFileName}\';');
+    
+    buffer.writeln('''
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
+part of \'${config.outputFileName}\';''');
     buffer.writeln();
   }
 

--- a/slang/lib/builder/generator/generate_translation_map.dart
+++ b/slang/lib/builder/generator/generate_translation_map.dart
@@ -8,7 +8,7 @@ String generateTranslationMap(
 
   if (config.outputFormat == OutputFormat.multipleFiles) {
     // this is a part file
-    
+
     buffer.writeln('''
 ///
 /// Generated file. Do not edit.

--- a/slang/lib/builder/generator/generate_translations.dart
+++ b/slang/lib/builder/generator/generate_translations.dart
@@ -28,7 +28,15 @@ String generateTranslations(GenerateConfig config, I18nData localeData) {
 
   if (config.outputFormat == OutputFormat.multipleFiles) {
     // this is a part file
-    buffer.writeln('part of \'${config.outputFileName}\';');
+
+    buffer.writeln('''
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
+part of \'${config.outputFileName}\';''');
   }
 
   queue.add(ClassTask(

--- a/slang/test/integration/resources/main/_expected_de.output
+++ b/slang/test/integration/resources/main/_expected_de.output
@@ -1,3 +1,9 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'translations.cgm.dart';
 
 // Path: <root>

--- a/slang/test/integration/resources/main/_expected_en.output
+++ b/slang/test/integration/resources/main/_expected_en.output
@@ -1,3 +1,9 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'translations.cgm.dart';
 
 // Path: <root>

--- a/slang/test/integration/resources/main/_expected_map.output
+++ b/slang/test/integration/resources/main/_expected_map.output
@@ -1,3 +1,9 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint
+
 part of 'translations.cgm.dart';
 
 /// Flat map(s) containing all translations.


### PR DESCRIPTION
### Issue
When generating files using `output_format: mutliple_files`, resulting files should have lint ignored and coverage disabled, similar to main generated file.

### Solution

- Added pre-defined comments too ignore lint and disable coverage for these generated files
- Updated tests to reflect new code lines
- Added additional warning that these files are generated and should not be edited

![gen_file_example](https://github.com/slang-i18n/slang/assets/41063241/2725934e-bff3-49e6-a244-daff28580669)
