### PR TITLE
perf: use `final` strings rather than getters

### DIFF
--- a/slang/lib/builder/generator/generate_translations.dart
+++ b/slang/lib/builder/generator/generate_translations.dart
@@ -300,7 +300,7 @@ void _generateClass(
       final stringLiteral = getStringLiteral(value.content, config.obfuscation);
       if (value.params.isEmpty) {
         buffer.writeln(
-            'String$optional get $key => $translationOverrides$stringLiteral;');
+            'late final String$optional $key = $translationOverrides$stringLiteral;');
       } else {
         buffer.writeln(
             'String$optional $key${_toParameterList(value.params, value.paramTypeMap)} => $translationOverrides$stringLiteral;');

--- a/slang/test/integration/resources/main/_expected_de.output
+++ b/slang/test/integration/resources/main/_expected_de.output
@@ -138,8 +138,8 @@ class _TranslationsOnboarding$pages$0i0$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Erste Seite';
-	@override String get content => 'Erster Seiteninhalt';
+	@override late final String title = 'Erste Seite';
+	@override late final String content = 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.pages.1
@@ -149,7 +149,7 @@ class _TranslationsOnboarding$pages$0i1$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Zweite Seite';
+	@override late final String title = 'Zweite Seite';
 }
 
 // Path: onboarding.modifierPages.0
@@ -159,8 +159,8 @@ class _TranslationsOnboarding$modifierPages$0i0$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Erste Modifier Seite';
-	@override String get content => 'Erster Seiteninhalt';
+	@override late final String title = 'Erste Modifier Seite';
+	@override late final String content = 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.modifierPages.1
@@ -170,5 +170,5 @@ class _TranslationsOnboarding$modifierPages$0i1$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Zweite Modifier Seite';
+	@override late final String title = 'Zweite Modifier Seite';
 }

--- a/slang/test/integration/resources/main/_expected_en.output
+++ b/slang/test/integration/resources/main/_expected_en.output
@@ -144,8 +144,8 @@ class _TranslationsOnboarding$pages$0i0$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'First Page';
-	@override String get content => 'First Page Content';
+	@override late final String title = 'First Page';
+	@override late final String content = 'First Page Content';
 }
 
 // Path: onboarding.pages.1
@@ -155,7 +155,7 @@ class _TranslationsOnboarding$pages$0i1$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Second Page';
+	@override late final String title = 'Second Page';
 }
 
 // Path: onboarding.modifierPages.0
@@ -165,8 +165,8 @@ class _TranslationsOnboarding$modifierPages$0i0$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'First Modifier Page';
-	@override String get content => 'First Page Content';
+	@override late final String title = 'First Modifier Page';
+	@override late final String content = 'First Page Content';
 }
 
 // Path: onboarding.modifierPages.1
@@ -176,5 +176,5 @@ class _TranslationsOnboarding$modifierPages$0i1$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Second Modifier Page';
+	@override late final String title = 'Second Modifier Page';
 }

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale.output
@@ -296,8 +296,8 @@ class _TranslationsOnboarding$pages$0i0$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'First Page';
-	@override String? get content => 'First Page Content';
+	@override late final String title = 'First Page';
+	@override late final String? content = 'First Page Content';
 }
 
 // Path: onboarding.pages.1
@@ -307,7 +307,7 @@ class _TranslationsOnboarding$pages$0i1$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Second Page';
+	@override late final String title = 'Second Page';
 }
 
 // Path: onboarding.modifierPages.0
@@ -317,8 +317,8 @@ class _TranslationsOnboarding$modifierPages$0i0$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'First Modifier Page';
-	@override String? get content => 'First Page Content';
+	@override late final String title = 'First Modifier Page';
+	@override late final String? content = 'First Page Content';
 }
 
 // Path: onboarding.modifierPages.1
@@ -328,7 +328,7 @@ class _TranslationsOnboarding$modifierPages$0i1$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Second Modifier Page';
+	@override late final String title = 'Second Modifier Page';
 }
 
 // Path: <root>
@@ -465,8 +465,8 @@ class _TranslationsOnboarding$pages$0i0$De extends _TranslationsOnboarding$pages
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Erste Seite';
-	@override String? get content => 'Erster Seiteninhalt';
+	@override late final String title = 'Erste Seite';
+	@override late final String? content = 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.pages.1
@@ -476,7 +476,7 @@ class _TranslationsOnboarding$pages$0i1$De extends _TranslationsOnboarding$pages
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Zweite Seite';
+	@override late final String title = 'Zweite Seite';
 }
 
 // Path: onboarding.modifierPages.0
@@ -486,8 +486,8 @@ class _TranslationsOnboarding$modifierPages$0i0$De extends _TranslationsOnboardi
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Erste Modifier Seite';
-	@override String? get content => 'Erster Seiteninhalt';
+	@override late final String title = 'Erste Modifier Seite';
+	@override late final String? content = 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.modifierPages.1
@@ -497,7 +497,7 @@ class _TranslationsOnboarding$modifierPages$0i1$De extends _TranslationsOnboardi
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Zweite Modifier Seite';
+	@override late final String title = 'Zweite Modifier Seite';
 }
 
 /// Flat map(s) containing all translations.

--- a/slang/test/integration/resources/main/_expected_no_flutter.output
+++ b/slang/test/integration/resources/main/_expected_no_flutter.output
@@ -104,7 +104,7 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 	late final Translations _root = this; // ignore: unused_field
 
 	// Translations
-	String get a => 'a';
+	late final String a = 'a';
 	late final _TranslationsBEn b = _TranslationsBEn._(_root);
 }
 
@@ -115,7 +115,7 @@ class _TranslationsBEn {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	String get bb => 'bb';
+	late final String bb = 'bb';
 }
 
 /// Flat map(s) containing all translations.

--- a/slang/test/integration/resources/main/_expected_no_locale_handling.output
+++ b/slang/test/integration/resources/main/_expected_no_locale_handling.output
@@ -74,7 +74,7 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 	late final Translations _root = this; // ignore: unused_field
 
 	// Translations
-	String get a => 'a';
+	late final String a = 'a';
 	late final TranslationsBEn b = TranslationsBEn._(_root);
 }
 
@@ -85,7 +85,7 @@ class TranslationsBEn {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	String get bb => 'bb';
+	late final String bb = 'bb';
 }
 
 /// Flat map(s) containing all translations.

--- a/slang/test/integration/resources/main/_expected_obfuscation.output
+++ b/slang/test/integration/resources/main/_expected_obfuscation.output
@@ -298,8 +298,8 @@ class _TranslationsOnboarding$pages$0i0$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([29, 50, 41, 40, 47, 123, 11, 58, 60, 62]);
-	@override String get content => _root.$meta.d([29, 50, 41, 40, 47, 123, 11, 58, 60, 62, 123, 24, 52, 53, 47, 62, 53, 47]);
+	@override late final String title = _root.$meta.d([29, 50, 41, 40, 47, 123, 11, 58, 60, 62]);
+	@override late final String content = _root.$meta.d([29, 50, 41, 40, 47, 123, 11, 58, 60, 62, 123, 24, 52, 53, 47, 62, 53, 47]);
 }
 
 // Path: onboarding.pages.1
@@ -309,7 +309,7 @@ class _TranslationsOnboarding$pages$0i1$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([8, 62, 56, 52, 53, 63, 123, 11, 58, 60, 62]);
+	@override late final String title = _root.$meta.d([8, 62, 56, 52, 53, 63, 123, 11, 58, 60, 62]);
 }
 
 // Path: onboarding.modifierPages.0
@@ -319,8 +319,8 @@ class _TranslationsOnboarding$modifierPages$0i0$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([29, 50, 41, 40, 47, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 11, 58, 60, 62]);
-	@override String get content => _root.$meta.d([29, 50, 41, 40, 47, 123, 11, 58, 60, 62, 123, 24, 52, 53, 47, 62, 53, 47]);
+	@override late final String title = _root.$meta.d([29, 50, 41, 40, 47, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 11, 58, 60, 62]);
+	@override late final String content = _root.$meta.d([29, 50, 41, 40, 47, 123, 11, 58, 60, 62, 123, 24, 52, 53, 47, 62, 53, 47]);
 }
 
 // Path: onboarding.modifierPages.1
@@ -330,7 +330,7 @@ class _TranslationsOnboarding$modifierPages$0i1$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([8, 62, 56, 52, 53, 63, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 11, 58, 60, 62]);
+	@override late final String title = _root.$meta.d([8, 62, 56, 52, 53, 63, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 11, 58, 60, 62]);
 }
 
 // Path: <root>
@@ -466,8 +466,8 @@ class _TranslationsOnboarding$pages$0i0$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([30, 41, 40, 47, 62, 123, 8, 62, 50, 47, 62]);
-	@override String get content => _root.$meta.d([30, 41, 40, 47, 62, 41, 123, 8, 62, 50, 47, 62, 53, 50, 53, 51, 58, 55, 47]);
+	@override late final String title = _root.$meta.d([30, 41, 40, 47, 62, 123, 8, 62, 50, 47, 62]);
+	@override late final String content = _root.$meta.d([30, 41, 40, 47, 62, 41, 123, 8, 62, 50, 47, 62, 53, 50, 53, 51, 58, 55, 47]);
 }
 
 // Path: onboarding.pages.1
@@ -477,7 +477,7 @@ class _TranslationsOnboarding$pages$0i1$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([1, 44, 62, 50, 47, 62, 123, 8, 62, 50, 47, 62]);
+	@override late final String title = _root.$meta.d([1, 44, 62, 50, 47, 62, 123, 8, 62, 50, 47, 62]);
 }
 
 // Path: onboarding.modifierPages.0
@@ -487,8 +487,8 @@ class _TranslationsOnboarding$modifierPages$0i0$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([30, 41, 40, 47, 62, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 8, 62, 50, 47, 62]);
-	@override String get content => _root.$meta.d([30, 41, 40, 47, 62, 41, 123, 8, 62, 50, 47, 62, 53, 50, 53, 51, 58, 55, 47]);
+	@override late final String title = _root.$meta.d([30, 41, 40, 47, 62, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 8, 62, 50, 47, 62]);
+	@override late final String content = _root.$meta.d([30, 41, 40, 47, 62, 41, 123, 8, 62, 50, 47, 62, 53, 50, 53, 51, 58, 55, 47]);
 }
 
 // Path: onboarding.modifierPages.1
@@ -498,7 +498,7 @@ class _TranslationsOnboarding$modifierPages$0i1$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => _root.$meta.d([1, 44, 62, 50, 47, 62, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 8, 62, 50, 47, 62]);
+	@override late final String title = _root.$meta.d([1, 44, 62, 50, 47, 62, 123, 22, 52, 63, 50, 61, 50, 62, 41, 123, 8, 62, 50, 47, 62]);
 }
 
 /// Flat map(s) containing all translations.

--- a/slang/test/integration/resources/main/_expected_rich_text.output
+++ b/slang/test/integration/resources/main/_expected_rich_text.output
@@ -152,7 +152,7 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 	late final Translations _root = this; // ignore: unused_field
 
 	// Translations
-	String get simple => 'Simple';
+	late final String simple = 'Simple';
 	String simpleParam({required Object simpleParam}) => 'Simple ${simpleParam}';
 	TextSpan get rich => TextSpan(children: [
 		const TextSpan(text: 'Rich'),

--- a/slang/test/integration/resources/main/_expected_single.output
+++ b/slang/test/integration/resources/main/_expected_single.output
@@ -296,8 +296,8 @@ class _TranslationsOnboarding$pages$0i0$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'First Page';
-	@override String get content => 'First Page Content';
+	@override late final String title = 'First Page';
+	@override late final String content = 'First Page Content';
 }
 
 // Path: onboarding.pages.1
@@ -307,7 +307,7 @@ class _TranslationsOnboarding$pages$0i1$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Second Page';
+	@override late final String title = 'Second Page';
 }
 
 // Path: onboarding.modifierPages.0
@@ -317,8 +317,8 @@ class _TranslationsOnboarding$modifierPages$0i0$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'First Modifier Page';
-	@override String get content => 'First Page Content';
+	@override late final String title = 'First Modifier Page';
+	@override late final String content = 'First Page Content';
 }
 
 // Path: onboarding.modifierPages.1
@@ -328,7 +328,7 @@ class _TranslationsOnboarding$modifierPages$0i1$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Second Modifier Page';
+	@override late final String title = 'Second Modifier Page';
 }
 
 // Path: <root>
@@ -463,8 +463,8 @@ class _TranslationsOnboarding$pages$0i0$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Erste Seite';
-	@override String get content => 'Erster Seiteninhalt';
+	@override late final String title = 'Erste Seite';
+	@override late final String content = 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.pages.1
@@ -474,7 +474,7 @@ class _TranslationsOnboarding$pages$0i1$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Zweite Seite';
+	@override late final String title = 'Zweite Seite';
 }
 
 // Path: onboarding.modifierPages.0
@@ -484,8 +484,8 @@ class _TranslationsOnboarding$modifierPages$0i0$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Erste Modifier Seite';
-	@override String get content => 'Erster Seiteninhalt';
+	@override late final String title = 'Erste Modifier Seite';
+	@override late final String content = 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.modifierPages.1
@@ -495,7 +495,7 @@ class _TranslationsOnboarding$modifierPages$0i1$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => 'Zweite Modifier Seite';
+	@override late final String title = 'Zweite Modifier Seite';
 }
 
 /// Flat map(s) containing all translations.

--- a/slang/test/integration/resources/main/_expected_translation_overrides.output
+++ b/slang/test/integration/resources/main/_expected_translation_overrides.output
@@ -330,8 +330,8 @@ class _TranslationsOnboarding$pages$0i0$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.title', {}) ?? 'First Page';
-	@override String get content => TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.content', {}) ?? 'First Page Content';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.title', {}) ?? 'First Page';
+	@override late final String content = TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.content', {}) ?? 'First Page Content';
 }
 
 // Path: onboarding.pages.1
@@ -341,7 +341,7 @@ class _TranslationsOnboarding$pages$0i1$En with PageData {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.pages.1.title', {}) ?? 'Second Page';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.pages.1.title', {}) ?? 'Second Page';
 }
 
 // Path: onboarding.modifierPages.0
@@ -351,8 +351,8 @@ class _TranslationsOnboarding$modifierPages$0i0$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.title', {}) ?? 'First Modifier Page';
-	@override String get content => TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.content', {}) ?? 'First Page Content';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.title', {}) ?? 'First Modifier Page';
+	@override late final String content = TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.content', {}) ?? 'First Page Content';
 }
 
 // Path: onboarding.modifierPages.1
@@ -362,7 +362,7 @@ class _TranslationsOnboarding$modifierPages$0i1$En with MPage {
 	final Translations _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.1.title', {}) ?? 'Second Modifier Page';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.1.title', {}) ?? 'Second Modifier Page';
 }
 
 // Path: <root>
@@ -505,8 +505,8 @@ class _TranslationsOnboarding$pages$0i0$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.title', {}) ?? 'Erste Seite';
-	@override String get content => TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.content', {}) ?? 'Erster Seiteninhalt';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.title', {}) ?? 'Erste Seite';
+	@override late final String content = TranslationOverrides.string(_root.$meta, 'onboarding.pages.0.content', {}) ?? 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.pages.1
@@ -516,7 +516,7 @@ class _TranslationsOnboarding$pages$0i1$De with PageData implements _Translation
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.pages.1.title', {}) ?? 'Zweite Seite';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.pages.1.title', {}) ?? 'Zweite Seite';
 }
 
 // Path: onboarding.modifierPages.0
@@ -526,8 +526,8 @@ class _TranslationsOnboarding$modifierPages$0i0$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.title', {}) ?? 'Erste Modifier Seite';
-	@override String get content => TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.content', {}) ?? 'Erster Seiteninhalt';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.title', {}) ?? 'Erste Modifier Seite';
+	@override late final String content = TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.0.content', {}) ?? 'Erster Seiteninhalt';
 }
 
 // Path: onboarding.modifierPages.1
@@ -537,7 +537,7 @@ class _TranslationsOnboarding$modifierPages$0i1$De with MPage implements _Transl
 	@override final _TranslationsDe _root; // ignore: unused_field
 
 	// Translations
-	@override String get title => TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.1.title', {}) ?? 'Zweite Modifier Seite';
+	@override late final String title = TranslationOverrides.string(_root.$meta, 'onboarding.modifierPages.1.title', {}) ?? 'Zweite Modifier Seite';
 }
 
 /// Flat map(s) containing all translations.


### PR DESCRIPTION
This PR swaps out getters for final strings in the generated `strings.g.dart` file, e.g.
```diff
-	String get pages => 'Pages';
+	late final String pages = 'Pages';
```

Reasoning:
- Might unlock some performance optimizations in the dart compiler (just speculating here)
- Semantically, final fields represent that these strings don't change (in a given locale) more clearly than getters
- Note that fields are marked as `late final` not just `final` to avoid an error about implicit `this` references:
  ```console
  lib/i18n/strings.g.dart:700:34: Error: Can't access 'this' in a field initializer to read '_root'.
    final String a = 'Tap on the "${_root.profile.quickLinks.deleteAccount}" button above';
                                    ^^^^^
  ```

I'm interested to see what you think about this (whether it's necessary or will make any difference) since this is just speculation 