### PR TITLE
fix: exclude comments from analysis during the execution of 'analyze'

### DIFF
--- a/slang/lib/src/runner/analyze.dart
+++ b/slang/lib/src/runner/analyze.dart
@@ -348,8 +348,8 @@ void _getUnusedTranslationsInSourceCodeRecursive({
 String loadSourceCode(List<File> files) {
   final buffer = StringBuffer();
   final spacesRegex = RegExp(r'\s');
-  final singleLineCommentsRegex = RegExp(r'\/\/.*');
-  final multiLineCommentsRegex = RegExp(r'\/\*.*?\*\/', multiLine: true);
+  final singleLineCommentsRegex = RegExp(r'//.*');
+  final multiLineCommentsRegex = RegExp(r'/\*.*?\*/', dotAll: true);
 
   for (final file in files) {
     buffer.write(file

--- a/slang/lib/src/runner/analyze.dart
+++ b/slang/lib/src/runner/analyze.dart
@@ -347,9 +347,16 @@ void _getUnusedTranslationsInSourceCodeRecursive({
 /// and joins them into a single (huge) string without any spaces.
 String loadSourceCode(List<File> files) {
   final buffer = StringBuffer();
-  final regex = RegExp(r'\s');
+  final spacesRegex = RegExp(r'\s');
+  final singleLineCommentsRegex = RegExp(r'\/\/.*');
+  final multiLineCommentsRegex = RegExp(r'\/\*.*?\*\/', multiLine: true);
+
   for (final file in files) {
-    buffer.write(file.readAsStringSync().replaceAll(regex, ''));
+    buffer.write(file
+        .readAsStringSync()
+        .replaceAll(singleLineCommentsRegex, '')
+        .replaceAll(multiLineCommentsRegex, '')
+        .replaceAll(spacesRegex, ''));
   }
 
   return buffer.toString();

--- a/slang/test/unit/runner/analyze_test.dart
+++ b/slang/test/unit/runner/analyze_test.dart
@@ -28,5 +28,29 @@ void main() {
 
       expect(result, 'ABCDEFGH;');
     });
+
+    test('should ignore inline comments', () {
+      final files = [
+        FakeFile('A // B\nC'),
+        FakeFile('D /* E */ F'),
+        FakeFile('G'),
+      ];
+
+      final result = loadSourceCode(files);
+
+      expect(result, 'ACDFG');
+    });
+
+    test('should ignore block comments', () {
+      final files = [
+        FakeFile('A /* B\nC */ D'),
+        FakeFile('E // F'),
+        FakeFile('G //'),
+      ];
+
+      final result = loadSourceCode(files);
+
+      expect(result, 'ADEG');
+    });
   });
 }


### PR DESCRIPTION
Currently, commented-out content is also being included as part of the analysis, so if the following code is present, the translation was considered to be in use. 💭 

```dart
//...
  @override
  Widget build(BuildContext context) {
    // get t variable, will trigger rebuild on locale change
    // otherwise just call t directly (if locale is not changeable)
    final t = Translations.of(context);

    return Scaffold(
      appBar: AppBar(
        // NOTE: Due to the presence of Text(t.mainScreen.title) in the comment, it was mistakenly considered to be in use.
        title: Text(""), // Text(t.mainScreen.title),
      ),
//...
```

As the behavior was not intended to be as such, commented-out content has been modified to be excluded from analysis when executing the analyze command. ✅ 