### PR TITLE
feat: sort input files before generating translations

### DIFF
--- a/slang/lib/builder/builder/slang_file_collection_builder.dart
+++ b/slang/lib/builder/builder/slang_file_collection_builder.dart
@@ -91,7 +91,6 @@ class SlangFileCollectionBuilder {
     return SlangFileCollection(
       config: config,
       files: files
-          .sortedBy((file) => file.path)
           .map((f) {
             final fileNameNoExtension =
                 PathUtils.getFileNameNoExtension(f.path);
@@ -140,7 +139,7 @@ class SlangFileCollectionBuilder {
             return null;
           })
           .whereNotNull()
-          .toList(),
+          .sortedBy((file) => '${file.locale}-${file.namespace}'),
     );
   }
 }

--- a/slang/lib/builder/builder/slang_file_collection_builder.dart
+++ b/slang/lib/builder/builder/slang_file_collection_builder.dart
@@ -91,6 +91,7 @@ class SlangFileCollectionBuilder {
     return SlangFileCollection(
       config: config,
       files: files
+          .sortedBy((file) => file.path)
           .map((f) {
             final fileNameNoExtension =
                 PathUtils.getFileNameNoExtension(f.path);

--- a/slang/test/unit/builder/slang_file_collection_builder_test.dart
+++ b/slang/test/unit/builder/slang_file_collection_builder_test.dart
@@ -35,8 +35,8 @@ void main() {
       );
 
       expect(model.files.length, 3);
-      expect(model.files[0].locale.language, 'en');
-      expect(model.files[1].locale.language, 'de');
+      expect(model.files[0].locale.language, 'de');
+      expect(model.files[1].locale.language, 'en');
       expect(model.files[2].locale.language, 'fr');
       expect(model.files[2].locale.country, 'FR');
     });
@@ -97,9 +97,9 @@ void main() {
 
       expect(model.files.length, 2);
       expect(model.files[0].locale.language, 'fr');
-      expect(model.files[0].namespace, 'dialogs');
+      expect(model.files[0].namespace, 'ab_cd');
       expect(model.files[1].locale.language, 'fr');
-      expect(model.files[1].namespace, 'ab_cd');
+      expect(model.files[1].namespace, 'dialogs');
     });
   });
 }


### PR DESCRIPTION
Close #210 

Sort input files in `SlangFileCollection.fromFileModel` so that they are treated in a fixed order.