### PR TITLE
feat: add support for gp4 turbo

### DIFF
--- a/slang_gpt/lib/model/gpt_model.dart
+++ b/slang_gpt/lib/model/gpt_model.dart
@@ -15,6 +15,10 @@ enum GptModel {
       defaultInputLength: 4000,
       costPerInputToken: 0.00003,
       costPerOutputToken: 0.00006),
+  gpt4_turbo('gpt-4-turbo', GptProvider.openai,
+      defaultInputLength: 64000,
+      costPerInputToken: 0.00001,
+      costPerOutputToken: 0.00002),
   ;
 
   const GptModel(


### PR DESCRIPTION
Unsure what was the proper method to calculate the default input length. It seems other models simply divide the model context by 2, but the comment below was using a different formula as `1.33 * model_context`. Opted to simply divide by 2