### PR TITLE
Allow escaping linked translations

### DIFF
--- a/slang/README.md
+++ b/slang/README.md
@@ -714,12 +714,10 @@ Optionally, you can escape linked translations with this syntax:
 
 ```json
 {
-
-   "fields": {
-    "name": "my name is {firstName}",
-    "nbsp": "\u00a0",
+  "fields": {
+    "nbsp": "\u00a0"
   },
-  "introduce": "Hello, @:fields.name:@@:fields.nbsp:@how are you?"
+  "message": "10@:common.nbsp:@Days"
 }
 ```
 

--- a/slang/README.md
+++ b/slang/README.md
@@ -709,6 +709,20 @@ If namespaces are used, then it has to be specified in the path too.
 
 [RichTexts](#-richtext) can also contain links! But only [RichTexts](#-richtext) can link to [RichTexts](#-richtext).
 
+Optionally, you can escape linked translations with this syntax: 
+
+
+```json
+{
+
+   "fields": {
+    "name": "my name is {firstName}",
+    "nbsp": "\u00a0",
+  },
+  "introduce": "Hello, @:fields.name:@@:fields.nbsp:@how are you?"
+}
+```
+
 ### ➤ Pluralization
 
 This library uses the concept defined [here](https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).

--- a/slang/README.md
+++ b/slang/README.md
@@ -717,7 +717,7 @@ Optionally, you can escape linked translations with this syntax:
   "fields": {
     "nbsp": "\u00a0"
   },
-  "message": "10@:{common.nbsp}Days"
+  "message": "10@:{fields.nbsp}Days"
 }
 ```
 

--- a/slang/README.md
+++ b/slang/README.md
@@ -717,7 +717,7 @@ Optionally, you can escape linked translations with this syntax:
   "fields": {
     "nbsp": "\u00a0"
   },
-  "message": "10@:common.nbsp:@Days"
+  "message": "10@:{common.nbsp}Days"
 }
 ```
 

--- a/slang/lib/builder/model/node.dart
+++ b/slang/lib/builder/model/node.dart
@@ -576,7 +576,7 @@ _ParseLinksResult _parseLinks({
 }) {
   final links = <String>{};
   final parsedContent = input.replaceAllMapped(RegexUtils.linkedRegex, (match) {
-    final linkedPath = match.group(1)!;
+    final linkedPath = (match.group(1) ?? match.group(2))!;
     links.add(linkedPath);
 
     if (linkParamMap == null) {

--- a/slang/lib/src/builder/utils/regex_utils.dart
+++ b/slang/lib/src/builder/utils/regex_utils.dart
@@ -4,8 +4,8 @@ class RegexUtils {
   /// 2 = argument of ${argument}
   static RegExp argumentsDartRegex = RegExp(r'(?<!\\)\$(?:([\w]+)|\{(.+?)\})');
 
-  /// matches @:translation.key
-  static RegExp linkedRegex = RegExp(r'@:(\w[\w|.]*\w|\w)');
+  /// matches @:translation.key or @:translation.key:@
+  static RegExp linkedRegex = RegExp(r'@:(\w[\w|.]*\w|\w)(:@)?');
 
   /// matches $hello, $ but not \$
   static RegExp dollarRegex = RegExp(r'([^\\]|^)\$');

--- a/slang/lib/src/builder/utils/regex_utils.dart
+++ b/slang/lib/src/builder/utils/regex_utils.dart
@@ -4,8 +4,12 @@ class RegexUtils {
   /// 2 = argument of ${argument}
   static RegExp argumentsDartRegex = RegExp(r'(?<!\\)\$(?:([\w]+)|\{(.+?)\})');
 
-  /// matches @:translation.key or @:translation.key:@
-  static RegExp linkedRegex = RegExp(r'@:(\w[\w|.]*\w|\w)(:@)?');
+  /// matches @:translation.key or @:{translation.key} but not \$@:translation.key
+  /// 1 = argument of @:translation.key
+  /// 2 = argument of @:{translation.key}
+  static RegExp linkedRegex = RegExp(
+    r'(?<!\\)@:(?:(\w[\w|.]*\w|\w)|\{(\w[\w|.]*\w|\w)\})',
+  );
 
   /// matches $hello, $ but not \$
   static RegExp dollarRegex = RegExp(r'([^\\]|^)\$');

--- a/slang/lib/src/builder/utils/regex_utils.dart
+++ b/slang/lib/src/builder/utils/regex_utils.dart
@@ -4,7 +4,7 @@ class RegexUtils {
   /// 2 = argument of ${argument}
   static RegExp argumentsDartRegex = RegExp(r'(?<!\\)\$(?:([\w]+)|\{(.+?)\})');
 
-  /// matches @:translation.key or @:{translation.key} but not \$@:translation.key
+  /// matches @:translation.key or @:{translation.key}, but not \@:translation.key
   /// 1 = argument of @:translation.key
   /// 2 = argument of @:{translation.key}
   static RegExp linkedRegex = RegExp(

--- a/slang/lib/src/builder/utils/string_interpolation_extensions.dart
+++ b/slang/lib/src/builder/utils/string_interpolation_extensions.dart
@@ -137,6 +137,19 @@ String _replaceBetween({
       }
     }
 
+    if (startIndex >= 2 &&
+        curr[startIndex - 1] == ':' &&
+        curr[startIndex - 2] == '@') {
+      // ignore because of preceding @: which indicates an escaped, linked translation
+      buffer.write(curr.substring(0, startIndex + 1));
+      if (startIndex + 1 < curr.length) {
+        curr = curr.substring(startIndex + startCharacterLength);
+        continue;
+      } else {
+        break;
+      }
+    }
+
     if (startIndex != 0) {
       // add prefix
       buffer.write(curr.substring(0, startIndex));

--- a/slang/test/unit/model/node_test.dart
+++ b/slang/test/unit/model/node_test.dart
@@ -271,6 +271,14 @@ void main() {
         expect(node.params, <String>{});
       });
 
+      test('with escaped links', () {
+        final test = r'@:.c@:a:@@:hi:@@:wow. @:nice.cool:@';
+        final node = textNode(test, StringInterpolation.dart);
+        expect(node.content,
+            r'@:.c${_root.a}${_root.hi}${_root.wow}. ${_root.nice.cool}');
+        expect(node.params, <String>{});
+      });
+
       test('with links and params', () {
         final test = r'@:a @:b';
         final node = textNode(test, StringInterpolation.dart, linkParamMap: {

--- a/slang/test/unit/model/node_test.dart
+++ b/slang/test/unit/model/node_test.dart
@@ -359,6 +359,23 @@ void main() {
         expect(node.content, r'Nice ${coolHi} ${wow} ${yes}a ${noYes}');
         expect(node.params, {'coolHi', 'wow', 'yes', 'noYes'});
       });
+
+      test('with links', () {
+        final test = r'{myArg} @:myLink';
+        final node = textNode(test, StringInterpolation.braces);
+        expect(node.content, r'${myArg} ${_root.myLink}');
+        expect(node.params, <String>{'myArg'});
+      });
+
+      test('with escaped links', () {
+        final test = r'{myArg} @:linkA @:{linkB}hello @:{linkC}';
+        final node = textNode(test, StringInterpolation.braces);
+        expect(
+          node.content,
+          r'${myArg} ${_root.linkA} ${_root.linkB}hello ${_root.linkC}',
+        );
+        expect(node.params, <String>{'myArg'});
+      });
     });
 
     group(StringInterpolation.doubleBraces, () {
@@ -413,6 +430,23 @@ void main() {
         );
         expect(node.content, r'Nice ${coolHi} ${wow} ${yes}a ${noYes}');
         expect(node.params, {'coolHi', 'wow', 'yes', 'noYes'});
+      });
+
+      test('with links', () {
+        final test = r'{{myArg}} @:myLink';
+        final node = textNode(test, StringInterpolation.doubleBraces);
+        expect(node.content, r'${myArg} ${_root.myLink}');
+        expect(node.params, <String>{'myArg'});
+      });
+
+      test('with escaped links', () {
+        final test = r'{{myArg}} @:linkA @:{linkB}hello @:{linkC}';
+        final node = textNode(test, StringInterpolation.doubleBraces);
+        expect(
+          node.content,
+          r'${myArg} ${_root.linkA} ${_root.linkB}hello ${_root.linkC}',
+        );
+        expect(node.params, <String>{'myArg'});
       });
     });
   });

--- a/slang/test/unit/model/node_test.dart
+++ b/slang/test/unit/model/node_test.dart
@@ -272,10 +272,10 @@ void main() {
       });
 
       test('with escaped links', () {
-        final test = r'@:.c@:a:@@:hi:@@:wow. @:nice.cool:@';
+        final test = r'@:.c@:{a}@:{hi}@:wow. @:{nice.cool} @:nice.cool';
         final node = textNode(test, StringInterpolation.dart);
         expect(node.content,
-            r'@:.c${_root.a}${_root.hi}${_root.wow}. ${_root.nice.cool}');
+            r'@:.c${_root.a}${_root.hi}${_root.wow}. ${_root.nice.cool} ${_root.nice.cool}');
         expect(node.params, <String>{});
       });
 


### PR DESCRIPTION
I ran into an issue with linking translations and having them immediately followed by another word character. 

Example:

```json
{
  "common": {
    "nbsp": "\u00a0",
    "@nbsp": "No-Break Space https://unicode-explorer.com/c/00A0",
  },
   "message": "10@:common.nbspDays"
}
```

Message is linking to `@:common.nbsp`, but the link will be interpreted as `@:common.nbspDays` which is invalid.
My PR adds the option to escape linked translations:

```json
{
  "common": {
    "nbsp": "\u00a0",
    "@nbsp": "No-Break Space https://unicode-explorer.com/c/00A0",
  },
   "message": "10@:{common.nbsp}Days"
}
```