### PR TITLE
fix: update plural resolver map

### DIFF
--- a/slang/README.md
+++ b/slang/README.md
@@ -714,7 +714,7 @@ Optionally, you can escape linked translations by surrounding the path with `{}`
 
 This library uses the concept defined [here](https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).
 
-Some languages have support out of the box. See [here](https://github.com/slang-i18n/slang/blob/main/slang/lib/api/plural_resolver_map.dart).
+Some languages have support out of the box. See [here](https://github.com/slang-i18n/slang/blob/main/slang/lib/src/api/plural_resolver_map.dart).
 
 Plurals are detected by the following keywords: `zero`, `one`, `two`, `few`, `many`, `other`.
 

--- a/slang/lib/src/api/singleton.dart
+++ b/slang/lib/src/api/singleton.dart
@@ -413,7 +413,7 @@ extension LocaleSettingsExt<E extends BaseAppLocale<E, T>,
 
   /// Sets plural resolvers.
   /// See https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
-  /// See https://github.com/slang-i18n/slang/blob/main/slang/lib/api/plural_resolver_map.dart
+  /// See https://github.com/slang-i18n/slang/blob/main/slang/lib/src/api/plural_resolver_map.dart
   /// Either specify [language], or [locale]. [locale] has precedence.
   Future<void> setPluralResolver({
     String? language,


### PR DESCRIPTION
# PR Summary
Commit 65d5833246652f194e4b2bea01bb48aa0664b34b moved the location of `plural_resolver_map.dart`. This PR adjusts sources to changes.