### PR TITLE
Feature add global generate enum

### DIFF
--- a/slang/lib/src/builder/builder/build_model_config_builder.dart
+++ b/slang/lib/src/builder/builder/build_model_config_builder.dart
@@ -17,6 +17,7 @@ extension BuildModelConfigBuilder on RawConfig {
       pluralOrdinal: pluralOrdinal,
       contexts: contexts,
       interfaces: interfaces,
+      generateEnum: generateEnum,
     );
   }
 }

--- a/slang/lib/src/builder/builder/raw_config_builder.dart
+++ b/slang/lib/src/builder/builder/raw_config_builder.dart
@@ -128,6 +128,7 @@ class RawConfigBuilder {
       format: (map['format'] as Map<String, dynamic>?)?.toFormatConfig() ??
           RawConfig.defaultFormatConfig,
       imports: map['imports']?.cast<String>() ?? RawConfig.defaultImports,
+      generateEnum: map['generate_enum'] ?? RawConfig.defaultGenerateEnum,
       rawMap: map,
     );
   }

--- a/slang/lib/src/builder/builder/translation_model_builder.dart
+++ b/slang/lib/src/builder/builder/translation_model_builder.dart
@@ -486,7 +486,7 @@ Map<String, Node> _parseMapNode({
               context = PendingContextType(
                 enumName: enumName,
                 defaultParameter: ContextType.DEFAULT_PARAMETER,
-                generateEnum: ContextType.defaultGenerateEnum,
+                generateEnum: config.generateEnum,
               );
               contextCollection[context.enumName] = context;
             }

--- a/slang/lib/src/builder/generator/generate_header.dart
+++ b/slang/lib/src/builder/generator/generate_header.dart
@@ -204,6 +204,7 @@ void _generateBuildConfig({
   }
   buffer.writeln('],');
   buffer.writeln('\tinterfaces: [], // currently not supported');
+  buffer.writeln('\tgenerateEnum: ${config.generateEnum},');
   buffer.writeln(');');
 }
 

--- a/slang/lib/src/builder/model/build_model_config.dart
+++ b/slang/lib/src/builder/model/build_model_config.dart
@@ -20,6 +20,7 @@ class BuildModelConfig {
   final List<String> pluralOrdinal;
   final List<ContextType> contexts;
   final List<InterfaceConfig> interfaces;
+  final bool generateEnum;
 
   BuildModelConfig({
     required this.fallbackStrategy,
@@ -35,5 +36,6 @@ class BuildModelConfig {
     required this.pluralOrdinal,
     required this.contexts,
     required this.interfaces,
+    required this.generateEnum,
   });
 }

--- a/slang/lib/src/builder/model/raw_config.dart
+++ b/slang/lib/src/builder/model/raw_config.dart
@@ -51,6 +51,7 @@ class RawConfig {
     width: FormatConfig.defaultWidth,
   );
   static const List<String> defaultImports = <String>[];
+  static const bool defaultGenerateEnum = true;
 
   final FileType fileType;
   final I18nLocale baseLocale;
@@ -86,6 +87,7 @@ class RawConfig {
   final ObfuscationConfig obfuscation;
   final FormatConfig format;
   final List<String> imports;
+  final bool generateEnum;
 
   /// Used by external tools to access the raw config. (e.g. slang_gpt)
   final Map<String, dynamic> rawMap;
@@ -124,6 +126,7 @@ class RawConfig {
     required this.obfuscation,
     required this.format,
     required this.imports,
+    required this.generateEnum,
     required this.rawMap,
   })  : fileType = _determineFileType(inputFilePattern),
         stringInterpolation =
@@ -156,6 +159,7 @@ class RawConfig {
     List<InterfaceConfig>? interfaces,
     ObfuscationConfig? obfuscation,
     FormatConfig? format,
+    bool? generateEnum,
   }) {
     return RawConfig(
       baseLocale: baseLocale ?? this.baseLocale,
@@ -192,6 +196,7 @@ class RawConfig {
       obfuscation: obfuscation ?? this.obfuscation,
       format: format ?? this.format,
       imports: imports,
+      generateEnum: generateEnum ?? this.generateEnum,
       rawMap: rawMap,
     );
   }
@@ -273,6 +278,7 @@ class RawConfig {
     print(
         ' -> format: ${format.enabled ? 'enabled (width=${format.width})' : 'disabled'}');
     print(' -> imports: $imports');
+    print(' -> generateEnum: $generateEnum');
   }
 
   static final defaultLocale =
@@ -312,6 +318,7 @@ class RawConfig {
     format: RawConfig.defaultFormatConfig,
     imports: RawConfig.defaultImports,
     className: RawConfig.defaultClassName,
+    generateEnum: RawConfig.defaultGenerateEnum,
     rawMap: {},
   );
 }

--- a/slang/test/integration/resources/main/_expected_translation_overrides_main.output
+++ b/slang/test/integration/resources/main/_expected_translation_overrides_main.output
@@ -36,6 +36,7 @@ final _buildConfig = BuildModelConfig(
 	pluralOrdinal: [],
 	contexts: [],
 	interfaces: [], // currently not supported
+	generateEnum: true,
 );
 
 /// Supported locales.

--- a/slang/test/unit/api/locale_settings_test.dart
+++ b/slang/test/unit/api/locale_settings_test.dart
@@ -76,6 +76,7 @@ class _AppLocaleUtils
             pluralOrdinal: [],
             contexts: [],
             interfaces: [],
+            generateEnum: true,
           ),
         );
 }


### PR DESCRIPTION
Fix #283

This PR introduces a global generate_enum configuration option. By default, it is set to true to prevent breaking changes.

Changes:

1. Added a global generate_enum config (default: true).
2. If set to false, enums will not be generated unless explicitly enabled.
3. This provides more flexibility for projects that do not require enum generation.