### PR TITLE
Add copy_with_meta slang option

### DIFF
--- a/slang/lib/src/api/locale.dart
+++ b/slang/lib/src/api/locale.dart
@@ -39,6 +39,10 @@ class TranslationMetadata<E extends BaseAppLocale<E, T>,
     _flatMapFunction = func;
   }
 
+  Node? getOverride(String path) {
+    return overrides[path];
+  }
+
   /// Decrypts the given [chars] by XOR-ing them with the secret [s].
   ///
   /// Keep in mind that this is not a secure encryption method.

--- a/slang/lib/src/api/translation_overrides.dart
+++ b/slang/lib/src/api/translation_overrides.dart
@@ -13,7 +13,7 @@ import 'package:slang/src/builder/utils/string_interpolation_extensions.dart';
 class TranslationOverrides {
   static String? string(
       TranslationMetadata meta, String path, Map<String, Object> param) {
-    final node = meta.overrides[path];
+    final node = meta.getOverride(path);
     if (node == null) {
       return null;
     }
@@ -27,7 +27,7 @@ class TranslationOverrides {
 
   static String? plural(
       TranslationMetadata meta, String path, Map<String, Object> param) {
-    final node = meta.overrides[path];
+    final node = meta.getOverride(path);
     if (node == null) {
       return null;
     }
@@ -61,7 +61,7 @@ class TranslationOverrides {
 
   static String? context(
       TranslationMetadata meta, String path, Map<String, Object> param) {
-    final node = meta.overrides[path];
+    final node = meta.getOverride(path);
     if (node == null) {
       return null;
     }
@@ -80,7 +80,7 @@ class TranslationOverrides {
   }
 
   static Map<String, String>? map(TranslationMetadata meta, String path) {
-    final node = meta.overrides[path];
+    final node = meta.getOverride(path);
     if (node == null) {
       return null;
     }
@@ -100,7 +100,7 @@ class TranslationOverrides {
   }
 
   static List<String>? list(TranslationMetadata meta, String path) {
-    final node = meta.overrides[path];
+    final node = meta.getOverride(path);
     if (node == null) {
       return null;
     }

--- a/slang/lib/src/builder/builder/generate_config_builder.dart
+++ b/slang/lib/src/builder/builder/generate_config_builder.dart
@@ -27,6 +27,7 @@ class GenerateConfigBuilder {
       translationClassVisibility: config.translationClassVisibility,
       renderFlatMap: config.renderFlatMap,
       translationOverrides: config.translationOverrides,
+      copyWithMeta: config.copyWithMeta,
       renderTimestamp: config.renderTimestamp,
       renderStatistics: config.renderStatistics,
       contexts: contexts,

--- a/slang/lib/src/builder/builder/raw_config_builder.dart
+++ b/slang/lib/src/builder/builder/raw_config_builder.dart
@@ -132,6 +132,7 @@ class RawConfigBuilder {
           RawConfig.defaultFormatConfig,
       imports: map['imports']?.cast<String>() ?? RawConfig.defaultImports,
       generateEnum: generateEnum,
+      copyWithMeta: map['copy_with_meta'] ?? RawConfig.defaultCopyWithMeta,
       rawMap: map,
     );
   }

--- a/slang/lib/src/builder/generator/generate_translations.dart
+++ b/slang/lib/src/builder/generator/generate_translations.dart
@@ -189,15 +189,25 @@ void _generateClass(
           '\t/// [AppLocaleUtils.buildWithOverrides] is recommended for overriding.');
     }
 
-    buffer.writeln(
-        '\t$finalClassName({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver})');
+    buffer.write(
+        '\t$finalClassName({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver');
+    if (config.copyWithMeta) {
+      buffer.write(
+          ', TranslationMetadata<${config.enumName}, ${config.className}>? meta');
+    }
+    buffer.writeln('})');
     if (!config.translationOverrides) {
       buffer.write(
           '\t\t: assert(overrides == null, \'Set "translation_overrides: true" in order to enable this feature.\'),\n\t\t  ');
     } else {
       buffer.write('\t\t: ');
     }
-    buffer.writeln('\$meta = TranslationMetadata(');
+    if (config.copyWithMeta) {
+      buffer.writeln('\$meta = meta ?? TranslationMetadata(');
+    } else {
+      buffer.writeln('\$meta = TranslationMetadata(');
+    }
+
     buffer.writeln(
         '\t\t    locale: ${config.enumName}.${localeData.locale.enumConstant},');
     buffer.writeln('\t\t    overrides: overrides ?? {},');
@@ -438,6 +448,15 @@ void _generateClass(
       );
     }
   });
+
+  if (config.copyWithMeta) {
+    buffer.writeln();
+    if (!localeData.base) {
+      buffer.writeln('@override ');
+    }
+    buffer.writeln(
+        '\t$rootClassName copyWithMeta(TranslationMetadata<${config.enumName}, ${config.className}> meta) => $rootClassName(meta: meta);');
+  }
 
   buffer.writeln('}');
 }

--- a/slang/lib/src/builder/model/generate_config.dart
+++ b/slang/lib/src/builder/model/generate_config.dart
@@ -28,6 +28,7 @@ class GenerateConfig {
   final List<Interface> interface; // may include more than in build config
   final ObfuscationConfig obfuscation;
   final List<String> imports;
+  final bool copyWithMeta;
 
   GenerateConfig({
     required this.buildConfig,
@@ -50,5 +51,6 @@ class GenerateConfig {
     required this.interface,
     required this.obfuscation,
     required this.imports,
+    required this.copyWithMeta,
   });
 }

--- a/slang/lib/src/builder/model/raw_config.dart
+++ b/slang/lib/src/builder/model/raw_config.dart
@@ -52,6 +52,7 @@ class RawConfig {
   );
   static const List<String> defaultImports = <String>[];
   static const bool defaultGenerateEnum = true;
+  static const bool defaultCopyWithMeta = false;
 
   final FileType fileType;
   final I18nLocale baseLocale;
@@ -88,6 +89,7 @@ class RawConfig {
   final FormatConfig format;
   final List<String> imports;
   final bool generateEnum;
+  final bool copyWithMeta;
 
   /// Used by external tools to access the raw config. (e.g. slang_gpt)
   final Map<String, dynamic> rawMap;
@@ -128,6 +130,7 @@ class RawConfig {
     required this.imports,
     required this.generateEnum,
     required this.rawMap,
+    required this.copyWithMeta,
   })  : fileType = _determineFileType(inputFilePattern),
         stringInterpolation =
             _determineFileType(inputFilePattern) == FileType.arb
@@ -160,6 +163,7 @@ class RawConfig {
     ObfuscationConfig? obfuscation,
     FormatConfig? format,
     bool? generateEnum,
+    bool? copyWithMeta,
   }) {
     return RawConfig(
       baseLocale: baseLocale ?? this.baseLocale,
@@ -198,6 +202,7 @@ class RawConfig {
       imports: imports,
       generateEnum: generateEnum ?? this.generateEnum,
       rawMap: rawMap,
+      copyWithMeta: copyWithMeta ?? this.copyWithMeta,
     );
   }
 
@@ -319,6 +324,7 @@ class RawConfig {
     imports: RawConfig.defaultImports,
     className: RawConfig.defaultClassName,
     generateEnum: RawConfig.defaultGenerateEnum,
+    copyWithMeta: RawConfig.defaultCopyWithMeta,
     rawMap: {},
   );
 }


### PR DESCRIPTION
👋 First off, **thank you** for this amazing library! I'm excited to submit my first PR to this project.

## What is this PR about?

This PR introduces `Translation.copyWithMeta()`, allowing users to supply a custom `TranslationMetadata` object and observe accessed translation keys.

## My Use Case

I need to track which strings are accessed on which screen to provide an in-app UI for live translation editing. This change enables me to implement that functionality efficiently.

## Code Changes

- Added a new` copy_with_meta` generator flag
- The generator now includes a `Translation.copyWithMeta()` method that accepts a `TranslationMetadata` object
- Introduced a new method in `TranslationMetadata`: `Node? getOverride(String path)`
- `TranslationOverrides` now uses `getOverride` instead of `TranslationMetadata.overrides[]`, allowing subclasses of `TranslationMetadata` to customize the behavior and intercept override accesses

## Example Usage

I've created an example app demonstrating this feature:

🔗 [Example App](https://github.com/vishna/slang/tree/scope_example/slang/example_scope) (see video below)

### 📽️ Video Demo

https://github.com/user-attachments/assets/5405156c-b392-445b-b342-d065977bf91a




