### PR TITLE
Fix: Preserve indentation in multiline yaml strings

### DIFF
--- a/slang/lib/src/builder/utils/yaml_writer.dart
+++ b/slang/lib/src/builder/utils/yaml_writer.dart
@@ -16,7 +16,7 @@ String _convertMapToYaml(Map<String, dynamic> map, int indent) {
       buffer.writeln();
       buffer.write(_convertListToYaml(value, indent + 1));
     } else {
-      buffer.writeln(_formatScalarValue(value));
+      buffer.writeln(_formatScalarValue(value, indent + 1));
     }
   });
 
@@ -37,22 +37,24 @@ String _convertListToYaml(List list, int indent) {
       buffer.writeln();
       buffer.write(_convertListToYaml(item, indent + 1));
     } else {
-      buffer.writeln(_formatScalarValue(item));
+      buffer.writeln(_formatScalarValue(item, indent + 1));
     }
   }
 
   return buffer.toString();
 }
 
-String _formatScalarValue(dynamic value) {
+String _formatScalarValue(dynamic value, int indent) {
   if (value is String) {
     if (value.contains('\n')) {
       // Using pipe notation for multiline strings
       final lines = value.split('\n');
       final endsWithNewline = value.endsWith('\n');
       final buffer = StringBuffer(endsWithNewline ? '|\n' : '|-\n');
+      final indentStr = '  ' * indent;
       for (final line in lines) {
-        buffer.write('  $line\n');
+        buffer.write(indentStr);
+        buffer.writeln(line);
       }
       return buffer.toString().trimRight();
     } else {

--- a/slang/test/unit/utils/yaml_writer_test.dart
+++ b/slang/test/unit/utils/yaml_writer_test.dart
@@ -76,6 +76,10 @@ nullable: null
       final input = {
         'without_nl': 'This is a\nmultiline string\n with several lines',
         'with_nl': 'This is a\nmultiline string\n with newline\n',
+        'indented': {
+          'with_nl': 'This is a\nmultiline string\n with newline\n',
+          'without_nl': 'This is a\nmultiline string\n with several lines'
+        }
       };
       final expected = '''without_nl: |-
   This is a
@@ -85,6 +89,15 @@ with_nl: |
   This is a
   multiline string
    with newline
+indented: 
+  with_nl: |
+    This is a
+    multiline string
+     with newline
+  without_nl: |-
+    This is a
+    multiline string
+     with several lines
 ''';
       expect(convertToYaml(input), equals(expected));
     });


### PR DESCRIPTION
Fixes an issue where multiline strings had a fixed indent of 2 spaces, causing a syntax error and subsequent `dart run slang` commands to fail