### PR TITLE
feat: Add Documentation comments to the generated translation file

### DIFF
--- a/slang/lib/src/builder/builder/generate_config_builder.dart
+++ b/slang/lib/src/builder/builder/generate_config_builder.dart
@@ -33,6 +33,7 @@ class GenerateConfigBuilder {
       interface: interfaces,
       obfuscation: config.obfuscation,
       imports: config.imports,
+      documentationComments: config.documentationComments,
     );
   }
 }

--- a/slang/lib/src/builder/builder/raw_config_builder.dart
+++ b/slang/lib/src/builder/builder/raw_config_builder.dart
@@ -132,6 +132,8 @@ class RawConfigBuilder {
           RawConfig.defaultFormatConfig,
       imports: map['imports']?.cast<String>() ?? RawConfig.defaultImports,
       generateEnum: generateEnum,
+      documentationComments: map['documentation_comments']?.cast<String>() ??
+          RawConfig.defaultDocumentationComments,
       rawMap: map,
     );
   }

--- a/slang/lib/src/builder/generator/generate_translations.dart
+++ b/slang/lib/src/builder/generator/generate_translations.dart
@@ -23,7 +23,7 @@ class ClassTask {
 /// all non-default locales has a postfix of their locale code
 /// e.g. Strings, StringsDe, StringsFr
 String generateTranslations(GenerateConfig config, I18nData localeData,
-    List<I18nData>? allTranslations) {
+    [List<I18nData> allTranslations = const []]) {
   final queue = Queue<ClassTask>();
   final buffer = StringBuffer();
 
@@ -74,7 +74,7 @@ String generateTranslations(GenerateConfig config, I18nData localeData,
       task.className,
       task.node,
       root,
-      allTranslations ?? <I18nData>[],
+      allTranslations,
     );
 
     root = false;

--- a/slang/lib/src/builder/generator/generate_translations.dart
+++ b/slang/lib/src/builder/generator/generate_translations.dart
@@ -339,6 +339,7 @@ void _generateClass(
           } else {
             buffer.writeln();
           }
+          bool hasDocumentationComments = false;
           for (final localeCode in config.documentationComments) {
             final targetLocale = allTranslations.firstWhere(
               (locale) => locale.locale.languageTag == localeCode,
@@ -346,7 +347,11 @@ void _generateClass(
             final translation =
                 _getTranslationForPath(targetLocale.root, value.path);
             if (translation != null) {
+              if (hasDocumentationComments) {
+                buffer.writeln('\t///');
+              }
               buffer.writeln('\t/// In $localeCode: \'$translation\'');
+              hasDocumentationComments = true;
             }
           }
           hasComment = true;

--- a/slang/lib/src/builder/generator/generator.dart
+++ b/slang/lib/src/builder/generator/generator.dart
@@ -14,7 +14,8 @@ class Generator {
     return BuildResult(
       main: generateHeader(config, translations),
       translations: {
-        for (final t in translations) t.locale: generateTranslations(config, t),
+        for (final t in translations)
+          t.locale: generateTranslations(config, t, translations),
       },
     );
   }

--- a/slang/lib/src/builder/model/generate_config.dart
+++ b/slang/lib/src/builder/model/generate_config.dart
@@ -28,6 +28,7 @@ class GenerateConfig {
   final List<Interface> interface; // may include more than in build config
   final ObfuscationConfig obfuscation;
   final List<String> imports;
+  final List<String> documentationComments;
 
   GenerateConfig({
     required this.buildConfig,
@@ -50,5 +51,6 @@ class GenerateConfig {
     required this.interface,
     required this.obfuscation,
     required this.imports,
+    required this.documentationComments,
   });
 }

--- a/slang/lib/src/builder/model/raw_config.dart
+++ b/slang/lib/src/builder/model/raw_config.dart
@@ -52,6 +52,7 @@ class RawConfig {
   );
   static const List<String> defaultImports = <String>[];
   static const bool defaultGenerateEnum = true;
+  static const List<String> defaultDocumentationComments = <String>[];
 
   final FileType fileType;
   final I18nLocale baseLocale;
@@ -88,6 +89,7 @@ class RawConfig {
   final FormatConfig format;
   final List<String> imports;
   final bool generateEnum;
+  final List<String> documentationComments;
 
   /// Used by external tools to access the raw config. (e.g. slang_gpt)
   final Map<String, dynamic> rawMap;
@@ -127,6 +129,7 @@ class RawConfig {
     required this.format,
     required this.imports,
     required this.generateEnum,
+    required this.documentationComments,
     required this.rawMap,
   })  : fileType = _determineFileType(inputFilePattern),
         stringInterpolation =
@@ -160,6 +163,7 @@ class RawConfig {
     ObfuscationConfig? obfuscation,
     FormatConfig? format,
     bool? generateEnum,
+    List<String>? documentationComments,
   }) {
     return RawConfig(
       baseLocale: baseLocale ?? this.baseLocale,
@@ -197,6 +201,8 @@ class RawConfig {
       format: format ?? this.format,
       imports: imports,
       generateEnum: generateEnum ?? this.generateEnum,
+      documentationComments:
+          documentationComments ?? this.documentationComments,
       rawMap: rawMap,
     );
   }
@@ -319,6 +325,7 @@ class RawConfig {
     imports: RawConfig.defaultImports,
     className: RawConfig.defaultClassName,
     generateEnum: RawConfig.defaultGenerateEnum,
+    documentationComments: RawConfig.defaultDocumentationComments,
     rawMap: {},
   );
 }

--- a/slang/test/integration/main/documentation_comments_test.dart
+++ b/slang/test/integration/main/documentation_comments_test.dart
@@ -1,0 +1,43 @@
+import 'package:slang/src/builder/decoder/json_decoder.dart';
+import 'package:slang/src/builder/generator_facade.dart';
+import 'package:slang/src/builder/model/i18n_locale.dart';
+import 'package:slang/src/builder/model/raw_config.dart';
+import 'package:slang/src/builder/model/translation_map.dart';
+import 'package:test/test.dart';
+
+import '../../util/resources_utils.dart';
+
+void main() {
+  late String enInput;
+  late String deInput;
+  late String expectedEnOutput;
+
+  setUp(() {
+    enInput = loadResource('main/json_documentation_comments_en.json');
+    deInput = loadResource('main/json_documentation_comments_de.json');
+    expectedEnOutput = loadResource(
+      'main/_expected_documentation_comments_en.output',
+    );
+  });
+
+  test('documentation comments', () {
+    final result = GeneratorFacade.generate(
+      rawConfig: RawConfig.defaultConfig.copyWith(
+        renderTimestamp: false,
+        documentationComments: ['en', 'de'],
+      ),
+      translationMap: TranslationMap()
+        ..addTranslations(
+          locale: I18nLocale.fromString('en'),
+          translations: JsonDecoder().decode(enInput),
+        )
+        ..addTranslations(
+          locale: I18nLocale.fromString('de'),
+          translations: JsonDecoder().decode(deInput),
+        ),
+      inputDirectoryHint: 'fake/path/integration',
+    );
+
+    expect(result.translations[I18nLocale(language: 'en')], expectedEnOutput);
+  });
+}

--- a/slang/test/integration/resources/main/_expected_documentation_comments_en.output
+++ b/slang/test/integration/resources/main/_expected_documentation_comments_en.output
@@ -1,0 +1,91 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+
+part of 'strings.g.dart';
+
+// Path: <root>
+typedef TranslationsEn = Translations; // ignore: unused_element
+class Translations implements BaseTranslations<AppLocale, Translations> {
+	/// Returns the current translations of the given [context].
+	///
+	/// Usage:
+	/// final t = Translations.of(context);
+	static Translations of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context).translations;
+
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final Translations _root = this; // ignore: unused_field
+
+	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+
+	// Translations
+
+	/// A simple greeting
+	///
+	/// In en: 'Hello World'
+	/// In de: 'Hallo Welt'
+	String get hello => 'Hello World';
+
+	String get helloAlias => _root.hello;
+	late final TranslationsGreetingEn greeting = TranslationsGreetingEn._(_root);
+	String counter({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(n,
+		one: 'You have {n} item',
+		other: 'You have {n} items',
+	);
+}
+
+// Path: greeting
+class TranslationsGreetingEn {
+	TranslationsGreetingEn._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// In en: 'Good Morning'
+	/// In de: 'Guten Morgen'
+	String get morning => 'Good Morning';
+
+	/// In en: 'Good Evening'
+	/// In de: 'Guten Abend'
+	String get evening => 'Good Evening';
+}
+
+/// Flat map(s) containing all translations.
+/// Only for edge cases! For simple maps, use the map function of this library.
+extension on Translations {
+	dynamic _flatMapFunction(String path) {
+		switch (path) {
+			case 'hello': return 'Hello World';
+			case 'helloAlias': return _root.hello;
+			case 'greeting.morning': return 'Good Morning';
+			case 'greeting.evening': return 'Good Evening';
+			case 'counter': return ({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(n,
+				one: 'You have {n} item',
+				other: 'You have {n} items',
+			);
+			default: return null;
+		}
+	}
+}
+

--- a/slang/test/integration/resources/main/_expected_documentation_comments_en.output
+++ b/slang/test/integration/resources/main/_expected_documentation_comments_en.output
@@ -43,6 +43,7 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 	/// A simple greeting
 	///
 	/// In en: 'Hello World'
+	///
 	/// In de: 'Hallo Welt'
 	String get hello => 'Hello World';
 
@@ -63,10 +64,12 @@ class TranslationsGreetingEn {
 	// Translations
 
 	/// In en: 'Good Morning'
+	///
 	/// In de: 'Guten Morgen'
 	String get morning => 'Good Morning';
 
 	/// In en: 'Good Evening'
+	///
 	/// In de: 'Guten Abend'
 	String get evening => 'Good Evening';
 }


### PR DESCRIPTION
add: #218


Adds optional documentation comments to generated translation files, showing translation values from different locales directly in the code.

- Added `documentationComments` configuration option
- Enhanced generator to include translation values in comments
- Added tests for the new feature
