### PR TITLE
feat: disable dart format on generated files

### DIFF
--- a/slang/lib/src/builder/generator/generate_header.dart
+++ b/slang/lib/src/builder/generator/generate_header.dart
@@ -120,7 +120,8 @@ void _generateHeaderComment({
 /// To regenerate, run: `dart run slang`$statisticsStr$timestampStr
 
 // coverage:ignore-file
-// ignore_for_file: type=lint, unused_import''');
+// ignore_for_file: type=lint, unused_import
+// dart format off''');
 }
 
 void _generateImports(GenerateConfig config, StringBuffer buffer) {

--- a/slang/lib/src/builder/generator/generate_translations.dart
+++ b/slang/lib/src/builder/generator/generate_translations.dart
@@ -36,6 +36,7 @@ String generateTranslations(GenerateConfig config, I18nData localeData,
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 ''');
 
   if (localeData.base) {

--- a/slang/test/integration/resources/main/_expected_de.output
+++ b/slang/test/integration/resources/main/_expected_de.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_en.output
+++ b/slang/test/integration/resources/main/_expected_en.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 part of 'translations.cgm.dart';
 

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_de.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_de.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_en.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_en.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 part of 'translations.cgm.dart';
 

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_main.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_main.output
@@ -8,6 +8,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_special_de.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_special_de.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_special_en.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_special_en.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 part of 'translations.cgm.dart';
 

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_special_main.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_special_main.output
@@ -8,6 +8,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_main.output
+++ b/slang/test/integration/resources/main/_expected_main.output
@@ -8,6 +8,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_no_flutter.output
+++ b/slang/test/integration/resources/main/_expected_no_flutter.output
@@ -8,6 +8,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:intl/intl.dart';
 import 'package:slang/generated.dart';

--- a/slang/test/integration/resources/main/_expected_no_locale_handling.output
+++ b/slang/test/integration/resources/main/_expected_no_locale_handling.output
@@ -8,6 +8,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_obfuscation_de.output
+++ b/slang/test/integration/resources/main/_expected_obfuscation_de.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_obfuscation_en.output
+++ b/slang/test/integration/resources/main/_expected_obfuscation_en.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 part of 'translations.cgm.dart';
 

--- a/slang/test/integration/resources/main/_expected_obfuscation_main.output
+++ b/slang/test/integration/resources/main/_expected_obfuscation_main.output
@@ -8,6 +8,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_rich_text.output
+++ b/slang/test/integration/resources/main/_expected_rich_text.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 part of 'strings.g.dart';
 

--- a/slang/test/integration/resources/main/_expected_translation_overrides_de.output
+++ b/slang/test/integration/resources/main/_expected_translation_overrides_de.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';

--- a/slang/test/integration/resources/main/_expected_translation_overrides_en.output
+++ b/slang/test/integration/resources/main/_expected_translation_overrides_en.output
@@ -3,6 +3,7 @@
 ///
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 part of 'translations.cgm.dart';
 

--- a/slang/test/integration/resources/main/_expected_translation_overrides_main.output
+++ b/slang/test/integration/resources/main/_expected_translation_overrides_main.output
@@ -8,6 +8,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import
+// dart format off
 
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';


### PR DESCRIPTION
Stops `dart format` from modifying these generated files.

https://github.com/dart-lang/dart_style/wiki/Configuration#disabling-formatting