### PR TITLE
feat: generate maps within same function

### DIFF
--- a/slang/lib/src/builder/generator/generate_translation_map.dart
+++ b/slang/lib/src/builder/generator/generate_translation_map.dart
@@ -31,22 +31,12 @@ String generateTranslationMap(
   }
 
   buffer.writeln('\tdynamic _flatMapFunction(String path) {');
-  buffer.write('\t\treturn ');
-  for (var i = 0; i < flatListSplits.length; i++) {
-    if (i == 0) {
-      buffer.write('_flatMapFunction\$$i(path)');
-    } else {
-      buffer.write('\n\t\t\t?? _flatMapFunction\$$i(path)');
-    }
-  }
-  buffer.writeln(';');
-  buffer.writeln('\t}');
 
   // Generate split functions
   for (var i = 0; i < flatListSplits.length; i++) {
-    buffer.writeln();
-    buffer.writeln('\tdynamic _flatMapFunction\$$i(String path) {');
-    buffer.writeln('\t\treturn switch (path) {');
+    final returnOrIfNull = switch (i) { 0 => '\t\treturn', _ => ' ??' };
+
+    buffer.writeln('$returnOrIfNull switch (path) {');
 
     _generateTranslationMap(
       buffer: buffer,
@@ -55,12 +45,14 @@ String generateTranslationMap(
       language: localeData.locale.language,
     );
 
-    buffer.writeln('\t\t\t_ => null,');
-    buffer.writeln('\t\t};');
-    buffer.writeln('\t}');
+    buffer.write('\t\t\t_ => null}');
   }
 
+  buffer.writeln(';');
+
+  buffer.writeln('\t}');
   buffer.writeln('}');
+  buffer.writeln('');
 
   return buffer.toString();
 }

--- a/slang/test/integration/resources/main/_expected_de.output
+++ b/slang/test/integration/resources/main/_expected_de.output
@@ -190,10 +190,6 @@ class _TranslationsOnboarding$modifierPages$0i1$De with MPage implements Transla
 /// so the map is split into smaller functions (512 entries each).
 extension on TranslationsDe {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => 'Willkommen ${fullName}',
 			'onboarding.welcomeAlias' => ({required Object fullName}) => _root.onboarding.welcome(fullName: fullName),
@@ -221,8 +217,8 @@ extension on TranslationsDe {
 			'end.pages.1.with space' => 'Ein Fehler',
 			'end.pages.1.with second space' => 'Ein 2. Fehler',
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('de'), one: () => TextSpan(children: [ const TextSpan(text: 'Eins'), ]), other: () => TextSpan(children: [ const TextSpan(text: 'Andere '), countBuilder(count), TextSpan(text: ', ${_root.onboarding.greet2(gender: gender)}'), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_en.output
+++ b/slang/test/integration/resources/main/_expected_en.output
@@ -235,10 +235,6 @@ class TranslationsOnboarding$modifierPages$0i1$En with MPage {
 /// so the map is split into smaller functions (512 entries each).
 extension on Translations {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => 'Welcome ${fullName}',
 			'onboarding.welcomeAlias' => ({required Object fullName}) => _root.onboarding.welcome(fullName: fullName),
@@ -266,8 +262,8 @@ extension on Translations {
 			'end.pages.1.with space' => 'An Error',
 			'end.pages.1.with second space' => 'An 2nd Error',
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'), one: () => TextSpan(children: [ const TextSpan(text: 'One'), ]), other: () => TextSpan(children: [ const TextSpan(text: 'Other '), countBuilder(count), TextSpan(text: ', ${_root.onboarding.greet2(gender: gender)}'), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_de.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_de.output
@@ -192,10 +192,6 @@ class _TranslationsOnboarding$modifierPages$0i1$De extends TranslationsOnboardin
 /// so the map is split into smaller functions (512 entries each).
 extension on TranslationsDe {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => 'Willkommen ${fullName}',
 			'onboarding.welcomeAlias' => ({required Object fullName}) => _root.onboarding.welcome(fullName: fullName),
@@ -223,8 +219,8 @@ extension on TranslationsDe {
 			'end.pages.1.with space' => 'Ein Fehler',
 			'end.pages.1.with second space' => 'Ein 2. Fehler',
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('de'), one: () => TextSpan(children: [ const TextSpan(text: 'Eins'), ]), other: () => TextSpan(children: [ const TextSpan(text: 'Andere '), countBuilder(count), TextSpan(text: ', ${_root.onboarding.greet2(gender: gender)}'), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_en.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_en.output
@@ -235,10 +235,6 @@ class TranslationsOnboarding$modifierPages$0i1$En with MPage {
 /// so the map is split into smaller functions (512 entries each).
 extension on Translations {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => 'Welcome ${fullName}',
 			'onboarding.welcomeAlias' => ({required Object fullName}) => _root.onboarding.welcome(fullName: fullName),
@@ -266,8 +262,8 @@ extension on Translations {
 			'end.pages.1.with space' => 'An Error',
 			'end.pages.1.with second space' => 'An 2nd Error',
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'), one: () => TextSpan(children: [ const TextSpan(text: 'One'), ]), other: () => TextSpan(children: [ const TextSpan(text: 'Other '), countBuilder(count), TextSpan(text: ', ${_root.onboarding.greet2(gender: gender)}'), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_special_de.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_special_de.output
@@ -56,14 +56,10 @@ class TranslationsDe extends Translations {
 /// so the map is split into smaller functions (512 entries each).
 extension on TranslationsDe {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'greet' => ({required Gender context}) { switch (context) { case Gender.male: return 'Hallo Herr'; case Gender.female: return 'Hello Mrs'; } }, 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_fallback_base_locale_special_en.output
+++ b/slang/test/integration/resources/main/_expected_fallback_base_locale_special_en.output
@@ -59,14 +59,10 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 /// so the map is split into smaller functions (512 entries each).
 extension on Translations {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'greet' => ({required Gender context}) { switch (context) { case Gender.male: return 'Hello Mr'; case Gender.female: return 'Hello Mrs'; } }, 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_obfuscation_de.output
+++ b/slang/test/integration/resources/main/_expected_obfuscation_de.output
@@ -192,10 +192,6 @@ class _TranslationsOnboarding$modifierPages$0i1$De with MPage implements Transla
 /// so the map is split into smaller functions (512 entries each).
 extension on TranslationsDe {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => _root.$meta.d([12, 50, 55, 55, 48, 52, 54, 54, 62, 53, 123]) + fullName.toString(),
 			'onboarding.welcomeAlias' => ({required Object fullName}) => _root.onboarding.welcome(fullName: fullName),
@@ -223,8 +219,8 @@ extension on TranslationsDe {
 			'end.pages.1.with space' => _root.$meta.d([30, 50, 53, 123, 29, 62, 51, 55, 62, 41]),
 			'end.pages.1.with second space' => _root.$meta.d([30, 50, 53, 123, 105, 117, 123, 29, 62, 51, 55, 62, 41]),
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('de'), one: () => TextSpan(children: [ TextSpan(text: _root.$meta.d([30, 50, 53, 40])), ]), other: () => TextSpan(children: [ TextSpan(text: _root.$meta.d([26, 53, 63, 62, 41, 62, 123])), countBuilder(count), TextSpan(text: _root.$meta.d([119, 123]) + _root.onboarding.greet2(gender: gender)), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_obfuscation_en.output
+++ b/slang/test/integration/resources/main/_expected_obfuscation_en.output
@@ -236,10 +236,6 @@ class TranslationsOnboarding$modifierPages$0i1$En with MPage {
 /// so the map is split into smaller functions (512 entries each).
 extension on Translations {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => _root.$meta.d([12, 62, 55, 56, 52, 54, 62, 123]) + fullName.toString(),
 			'onboarding.welcomeAlias' => ({required Object fullName}) => _root.onboarding.welcome(fullName: fullName),
@@ -267,8 +263,8 @@ extension on Translations {
 			'end.pages.1.with space' => _root.$meta.d([26, 53, 123, 30, 41, 41, 52, 41]),
 			'end.pages.1.with second space' => _root.$meta.d([26, 53, 123, 105, 53, 63, 123, 30, 41, 41, 52, 41]),
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'), one: () => TextSpan(children: [ TextSpan(text: _root.$meta.d([20, 53, 62])), ]), other: () => TextSpan(children: [ TextSpan(text: _root.$meta.d([20, 47, 51, 62, 41, 123])), countBuilder(count), TextSpan(text: _root.$meta.d([119, 123]) + _root.onboarding.greet2(gender: gender)), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_rich_text.output
+++ b/slang/test/integration/resources/main/_expected_rich_text.output
@@ -170,10 +170,6 @@ class Translations implements BaseTranslations<AppLocale, Translations> {
 /// so the map is split into smaller functions (512 entries each).
 extension on Translations {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'simple' => 'Simple',
 			'simpleParam' => ({required Object simpleParam}) => 'Simple ${simpleParam}',
@@ -190,8 +186,8 @@ extension on Translations {
 			'contextWithParameter' => ({required Animal context}) { switch (context) { case Animal.cat: return 'Miaw'; case Animal.dog: return 'Woof ${context}'; } }, 
 			'simpleRichContext' => ({required Animal context}) { switch (context) { case Animal.cat: return TextSpan(children: [ const TextSpan(text: 'Miaw'), ]); case Animal.dog: return TextSpan(children: [ const TextSpan(text: 'Woof'), ]); } }, 
 			'richContextWithParameter' => ({required Animal context, required InlineSpan Function(Animal) contextBuilder}) { switch (context) { case Animal.cat: return TextSpan(children: [ const TextSpan(text: 'Miaw'), ]); case Animal.dog: return TextSpan(children: [ const TextSpan(text: 'Woof '), contextBuilder(context), ]); } }, 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_translation_overrides_de.output
+++ b/slang/test/integration/resources/main/_expected_translation_overrides_de.output
@@ -199,10 +199,6 @@ class _TranslationsOnboarding$modifierPages$0i1$De with MPage implements Transla
 /// so the map is split into smaller functions (512 entries each).
 extension on TranslationsDe {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => TranslationOverrides.string(_root.$meta, 'onboarding.welcome', {'fullName': fullName}) ?? 'Willkommen ${fullName}',
 			'onboarding.welcomeAlias' => ({required Object fullName}) => TranslationOverrides.string(_root.$meta, 'onboarding.welcomeAlias', {'fullName': fullName}) ?? _root.onboarding.welcome(fullName: fullName),
@@ -230,8 +226,8 @@ extension on TranslationsDe {
 			'end.pages.1.with space' => TranslationOverrides.string(_root.$meta, 'end.pages.1.with space', {}) ?? 'Ein Fehler',
 			'end.pages.1.with second space' => TranslationOverrides.string(_root.$meta, 'end.pages.1.with second space', {}) ?? 'Ein 2. Fehler',
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => TranslationOverridesFlutter.richPlural(_root.$meta, 'advancedPlural', {'gender': gender, 'count': count, 'countBuilder': countBuilder}) ?? RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('de'), one: () => TextSpan(children: [ const TextSpan(text: 'Eins'), ]), other: () => TextSpan(children: [ const TextSpan(text: 'Andere '), countBuilder(count), TextSpan(text: ', ${_root.onboarding.greet2(gender: gender)}'), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 

--- a/slang/test/integration/resources/main/_expected_translation_overrides_en.output
+++ b/slang/test/integration/resources/main/_expected_translation_overrides_en.output
@@ -243,10 +243,6 @@ class TranslationsOnboarding$modifierPages$0i1$En with MPage {
 /// so the map is split into smaller functions (512 entries each).
 extension on Translations {
 	dynamic _flatMapFunction(String path) {
-		return _flatMapFunction$0(path);
-	}
-
-	dynamic _flatMapFunction$0(String path) {
 		return switch (path) {
 			'onboarding.welcome' => ({required Object fullName}) => TranslationOverrides.string(_root.$meta, 'onboarding.welcome', {'fullName': fullName}) ?? 'Welcome ${fullName}',
 			'onboarding.welcomeAlias' => ({required Object fullName}) => TranslationOverrides.string(_root.$meta, 'onboarding.welcomeAlias', {'fullName': fullName}) ?? _root.onboarding.welcome(fullName: fullName),
@@ -274,8 +270,8 @@ extension on Translations {
 			'end.pages.1.with space' => TranslationOverrides.string(_root.$meta, 'end.pages.1.with space', {}) ?? 'An Error',
 			'end.pages.1.with second space' => TranslationOverrides.string(_root.$meta, 'end.pages.1.with second space', {}) ?? 'An 2nd Error',
 			'advancedPlural' => ({required num count, required InlineSpan Function(num) countBuilder, required GenderContext gender}) => TranslationOverridesFlutter.richPlural(_root.$meta, 'advancedPlural', {'gender': gender, 'count': count, 'countBuilder': countBuilder}) ?? RichPluralResolvers.bridge( n: count, resolver: _root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'), one: () => TextSpan(children: [ const TextSpan(text: 'One'), ]), other: () => TextSpan(children: [ const TextSpan(text: 'Other '), countBuilder(count), TextSpan(text: ', ${_root.onboarding.greet2(gender: gender)}'), ]), ), 
-			_ => null,
-		};
+			_ => null};
 	}
 }
+
 


### PR DESCRIPTION
The last PR (#323) helped, but there were still a lot of conflicts. This change removes the extra split functions and inlines the logic using a `switch` with `??`. Keeping everything on a single line makes the generated code smaller and should cut down merge conflicts even more.
