### PR TITLE
feat: add Gemini API provider support

### DIFF
--- a/slang_gpt/README.md
+++ b/slang_gpt/README.md
@@ -4,7 +4,7 @@ Use GPT to automatically translate your app at compile time.
 
 This is library is intended to be used with [slang](https://pub.dev/packages/slang).
 
-Currently, only the [OpenAI API](https://platform.openai.com/docs/) is supported.
+Currently, only [OpenAI API](https://platform.openai.com/docs/) and [Google Gemini](https://ai.google.dev/gemini-api/docs) are supported.
 
 ## Motivation
 
@@ -53,6 +53,7 @@ dart run slang_gpt --target=fr --api-key=<api-key>
 
 | Key                | Type     | Usage                            | Required | Default             |
 |--------------------|----------|----------------------------------|----------|---------------------|
+| `provider`         | `String` | Provider                         | NO       | (inferred by model) |
 | `model`            | `String` | Model name                       | YES      |                     |
 | `max_input_length` | `int`    | Max input characters per request | NO       | (inferred by model) |
 | `temperature`      | `double` | Temperature parameter for GPT    | NO       | (API default)       |
@@ -71,14 +72,16 @@ dart run slang_gpt --target=fr --api-key=<api-key>
 
 ## Models
 
-| Model name          | Provider | Context length | Cost per 1k input token | Cost per 1k output token |
-|---------------------|----------|----------------|-------------------------|--------------------------|
-| `gpt-3.5-turbo`     | Open AI  | 4096           | $0.0005                 | $0.0015                  |
-| `gpt-3.5-turbo-16k` | Open AI  | 16384          | $0.003                  | $0.004                   |
-| `gpt-4`             | Open AI  | 8192           | $0.03                   | $0.06                    |
-| `gpt-4-turbo`       | Open AI  | 64000          | $0.01                   | $0.03                    |
-| `gpt-4o`            | Open AI  | 128000         | $0.005                  | $0.015                   |
-| `gpt-4o-mini`       | Open AI  | 128000         | $0.00015                | $0.0006                  |
+| Model name              | Provider | Context length | Cost per 1k input token | Cost per 1k output token |
+|-------------------------|----------|----------------|-------------------------|--------------------------|
+| `gpt-3.5-turbo`         | Open AI  | 4096           | $0.0005                 | $0.0015                  |
+| `gpt-3.5-turbo-16k`     | Open AI  | 16384          | $0.003                  | $0.004                   |
+| `gpt-4`                 | Open AI  | 8192           | $0.03                   | $0.06                    |
+| `gpt-4-turbo`           | Open AI  | 64000          | $0.01                   | $0.03                    |
+| `gpt-4o`                | Open AI  | 128000         | $0.005                  | $0.015                   |
+| `gpt-4o-mini`           | Open AI  | 128000         | $0.00015                | $0.0006                  |
+| `gemini-2.5-flash`      | Gemini   | 1048576        | $0.0                    | $0.0                     |
+| `gemini-2.5-flash-lite` | Gemini   | 1048576        | $0.0                    | $0.0                     |
 
 1k tokens = 750 words (English)
 

--- a/slang_gpt/lib/model/gpt_config.dart
+++ b/slang_gpt/lib/model/gpt_config.dart
@@ -38,9 +38,12 @@ class GptConfig {
       throw 'Missing gpt entry in config.';
     }
 
-    final model = GptModel.values.firstWhereOrNull((e) => e.id == gpt['model']);
+    final model = GptModel.values.firstWhereOrNull((e) =>
+        e.id == gpt['model'] &&
+        (gpt['provider'] == null || e.provider.name == gpt['provider']));
+
     if (model == null) {
-      throw 'Unknown model: ${gpt['model']}\nAvailable models: ${GptModel.values.map((e) => e.id).join(', ')}';
+      throw 'Unknown model: ${gpt['model']}${gpt['provider'] == null ? '' : ' of provider ${gpt['provider']}'}\nAvailable Providers models:\n\t${GptModel.values.groupListsBy((e) => e.provider).entries.map((e) => '${e.key.name}: ${e.value.map((e) => e.id).join(', ')}').join('\n\t')}';
     }
 
     final description = gpt['description'];

--- a/slang_gpt/lib/model/gpt_model.dart
+++ b/slang_gpt/lib/model/gpt_model.dart
@@ -1,5 +1,6 @@
 enum GptProvider {
   openai,
+  gemini,
 }
 
 // ignore_for_file: constant_identifier_names
@@ -39,7 +40,15 @@ enum GptModel {
   gpt5_mini('gpt-5-mini', GptProvider.openai,
       defaultInputLength: 400000,
       costPer1kInputToken: 0.00025,
-      costPer1kOutputToken: 0.002);
+      costPer1kOutputToken: 0.002),
+  gemini_2_5_flash('gemini-2.5-flash', GptProvider.gemini,
+      defaultInputLength: 400000,
+      costPer1kInputToken: 0.0,
+      costPer1kOutputToken: 0.0),
+  gemini_2_5_flash_lite('gemini-2.5-flash-lite', GptProvider.gemini,
+      defaultInputLength: 400000,
+      costPer1kInputToken: 0.0,
+      costPer1kOutputToken: 0.0);
 
   const GptModel(
     this.id,


### PR DESCRIPTION
## Description
Adds support for Google's Gemini API as an alternative to OpenAI for translation context generation, addressing the need for free tier API access.

## Changes
- ✅ Add `GptProvider.gemini` enum value
- ✅ Implement Gemini native API (`v1beta/models/{model}:generateContent`)
- ✅ Add 2 Gemini 2.5 models (Flash, Flash-Lite) with free tier
- ✅ Add optional `provider` config parameter for model disambiguation
- ✅ Configure `responseMimeType: application/json` for structured output
- ✅ Update README with Gemini models documentation

## Models Added
| Model | Context Length | RPM | TPM | RPD | Cost |
|-------|----------------|-----|-----|-----|------|
| gemini-2.5-flash | 1M tokens | 5 | 250K | 20 | Free |
| gemini-2.5-flash-lite | 1M tokens | 10 | 250K | 20 | Free |

## Configuration Example
```yaml
gpt:
  model: gemini-2.5-flash
  provider: gemini  # Optional, inferred from model name
```

## API Differences
- **Endpoint**: Uses Gemini's native `generateContent` instead of OpenAI-compatible endpoint
- **Auth**: Uses `x-goog-api-key` header instead of `Authorization: Bearer`
- **Request**: Uses `system_instruction` + `contents` structure
- **Response**: Parses `candidates[0].content.parts[0].text` structure
- **JSON Mode**: Uses `responseMimeType: application/json` in `generationConfig`

## Testing
- [x] Tested with gemini-2.5-flash
- [x] Verified structured JSON output
- [x] Confirmed token counting accuracy
- [x] Validated error handling

## Breaking Changes
None - backwards compatible addition

## Related Issues
Closes #334