### PR TITLE
slang_gpt: Allow to override description from command line

### DIFF
--- a/slang_gpt/README.md
+++ b/slang_gpt/README.md
@@ -68,6 +68,7 @@ dart run slang_gpt --target=fr --api-key=<api-key>
 | `-f` / `--full`  | Skip partial translation | NO       | (partial translation)  |
 | `-d` / `--debug` | Write chat to file       | NO       | (no chat output)       |
 | `--outdir=`      | Output directory         | NO*      | (using config)         |
+| `--description=` | App description          | NO       | (using config)         |
 
 ## Models
 

--- a/slang_gpt/lib/prompt/prompt.dart
+++ b/slang_gpt/lib/prompt/prompt.dart
@@ -17,14 +17,15 @@ List<GptPrompt> getPrompts({
   required I18nLocale targetLocale,
   required GptConfig config,
   required String? namespace,
+  required String? description,
   required Map<String, dynamic> translations,
 }) {
   final systemPrompt = _getSystemPrompt(
-    rawConfig: rawConfig,
-    targetLocale: targetLocale,
-    config: config,
-    namespace: namespace,
-  );
+      rawConfig: rawConfig,
+      targetLocale: targetLocale,
+      config: config,
+      namespace: namespace,
+      description: description ?? config.description);
   final systemPromptLength = systemPrompt.length;
 
   final prompts = <GptPrompt>[];
@@ -70,6 +71,7 @@ String _getSystemPrompt({
   required I18nLocale targetLocale,
   required GptConfig config,
   required String? namespace,
+  required String description,
 }) {
   final String interpolationHint;
   switch (rawConfig.stringInterpolation) {
@@ -97,5 +99,5 @@ Parameters are interpolated with $interpolationHint.
 Linked translations are denoted with the "@:path0.path1" syntax.
 
 Here is the app description. Respect this context when translating:
-${config.description}''';
+$description''';
 }

--- a/slang_gpt/lib/runner.dart
+++ b/slang_gpt/lib/runner.dart
@@ -38,6 +38,7 @@ Future<void> runGpt(List<String> arguments) async {
   String? outDir;
   bool debug = false;
   bool full = false;
+  String? description;
   for (final a in arguments) {
     if (a.startsWith('--api-key=')) {
       apiKey = a.substring(10);
@@ -55,6 +56,8 @@ Future<void> runGpt(List<String> arguments) async {
       full = true;
     } else if (a == '-d' || a == '--debug') {
       debug = true;
+    } else if (a.startsWith('--description=')) {
+      description = a.substring(14);
     }
   }
 
@@ -132,6 +135,7 @@ Future<void> runGpt(List<String> arguments) async {
           outDir: outDir,
           full: full,
           debug: debug,
+          description: description,
           file: file,
           originalTranslations: originalTranslations,
           apiKey: apiKey,
@@ -152,6 +156,7 @@ Future<void> runGpt(List<String> arguments) async {
           outDir: outDir,
           full: full,
           debug: debug,
+          description: description,
           file: file,
           originalTranslations: originalTranslations,
           apiKey: apiKey,
@@ -194,6 +199,7 @@ Future<TranslateMetrics> _translate({
   required String outDir,
   required bool full,
   required bool debug,
+  required String? description,
   required TranslationFile file,
   required Map<String, dynamic> originalTranslations,
   required String apiKey,
@@ -259,6 +265,7 @@ Future<TranslateMetrics> _translate({
     targetLocale: targetLocale,
     config: gptConfig,
     namespace: fileCollection.config.namespaces ? file.namespace : null,
+    description: description,
     translations: inputTranslations,
   );
 

--- a/slang_gpt/test/unit/prompt/prompt_test.dart
+++ b/slang_gpt/test/unit/prompt/prompt_test.dart
@@ -30,6 +30,7 @@ void main() {
           excludes: [],
         ),
         namespace: null,
+        description: null,
         translations: {
           'calculate': 'Calculate',
           'add': 'Add',
@@ -59,6 +60,7 @@ void main() {
           excludes: [],
         ),
         namespace: null,
+        description: null,
         translations: {
           'a': 'a',
           'b': 'b',
@@ -97,6 +99,7 @@ void main() {
           excludes: [],
         ),
         namespace: 'settings',
+        description: null,
         translations: {
           'a': 'a',
         },


### PR DESCRIPTION
Allow to override app description defined in `build.yaml` for `slang_gpt` from the command line.

This is useful when using a per-language app description that includes an approved dictionary to ensure translations are consistent.
