### PR TITLE
tweak: format yaml like weblate does

### DIFF
--- a/slang/lib/src/builder/utils/yaml_writer.dart
+++ b/slang/lib/src/builder/utils/yaml_writer.dart
@@ -2,19 +2,24 @@ String convertToYaml(Map<String, dynamic> content) {
   return _convertMapToYaml(content, 0);
 }
 
-String _convertMapToYaml(Map<String, dynamic> map, int indent) {
+String _convertMapToYaml(Map<String, dynamic> map, int indent,
+    {bool indentFirstLine = true}) {
   final buffer = StringBuffer();
   final indentStr = '  ' * indent;
+  var isFirstLine = true;
 
   map.forEach((key, value) {
-    buffer.write('$indentStr${_sanitizeStringValue(key)}:');
+    if (indentFirstLine || !isFirstLine) buffer.write(indentStr);
+    isFirstLine = false;
+
+    buffer.write('${_sanitizeStringValue(key)}:');
 
     if (value is Map<String, dynamic>) {
       buffer.writeln();
       buffer.write(_convertMapToYaml(value, indent + 1));
     } else if (value is List) {
       buffer.writeln();
-      buffer.write(_convertListToYaml(value, indent + 1));
+      buffer.write(_convertListToYaml(value, indent));
     } else {
       buffer.write(' ');
       buffer.writeln(_formatScalarValue(value, indent + 1));
@@ -29,15 +34,16 @@ String _convertListToYaml(List list, int indent) {
   final indentStr = '  ' * indent;
 
   for (var item in list) {
-    buffer.write('$indentStr- ');
+    buffer.write('$indentStr-');
 
     if (item is Map<String, dynamic>) {
-      buffer.writeln();
-      buffer.write(_convertMapToYaml(item, indent + 1));
+      buffer.write(' ');
+      buffer.write(_convertMapToYaml(item, indent + 1, indentFirstLine: false));
     } else if (item is List) {
       buffer.writeln();
       buffer.write(_convertListToYaml(item, indent + 1));
     } else {
+      buffer.write(' ');
       buffer.writeln(_formatScalarValue(item, indent + 1));
     }
   }

--- a/slang/lib/src/builder/utils/yaml_writer.dart
+++ b/slang/lib/src/builder/utils/yaml_writer.dart
@@ -7,7 +7,7 @@ String _convertMapToYaml(Map<String, dynamic> map, int indent) {
   final indentStr = '  ' * indent;
 
   map.forEach((key, value) {
-    buffer.write('$indentStr${_sanitizeStringValue(key)}: ');
+    buffer.write('$indentStr${_sanitizeStringValue(key)}:');
 
     if (value is Map<String, dynamic>) {
       buffer.writeln();
@@ -16,6 +16,7 @@ String _convertMapToYaml(Map<String, dynamic> map, int indent) {
       buffer.writeln();
       buffer.write(_convertListToYaml(value, indent + 1));
     } else {
+      buffer.write(' ');
       buffer.writeln(_formatScalarValue(value, indent + 1));
     }
   });

--- a/slang/test/unit/utils/yaml_writer_test.dart
+++ b/slang/test/unit/utils/yaml_writer_test.dart
@@ -31,9 +31,9 @@ nullable: null
           'details': {'age': 28, 'job': 'Engineer'}
         }
       };
-      final expected = '''person: 
+      final expected = '''person:
   name: Alice
-  details: 
+  details:
     age: 28
     job: Engineer
 ''';
@@ -56,7 +56,7 @@ nullable: null
           'normal': 'normal'
         }
       };
-      final expected = r'''special: 
+      final expected = r'''special:
   empty: ""
   with_question: "? a"
   "with:colon": inner spaces
@@ -89,7 +89,7 @@ with_nl: |
   This is a
   multiline string
    with newline
-indented: 
+indented:
   with_nl: |
     This is a
     multiline string
@@ -106,7 +106,7 @@ indented:
       final input = {
         'fruits': ['apple', 'banana', 'cherry'],
       };
-      final expected = '''fruits: 
+      final expected = '''fruits:
   - apple
   - banana
   - cherry
@@ -121,7 +121,7 @@ indented:
           {'type': 'phone', 'value': '555-1234'}
         ]
       };
-      final expected = '''contacts: 
+      final expected = '''contacts:
   - 
     type: email
     value: john@example.com
@@ -153,12 +153,12 @@ indented:
           ]
         }
       };
-      final expected = '''company: 
+      final expected = '''company:
   name: Acme Inc
-  departments: 
+  departments:
     - 
       name: Engineering
-      employees: 
+      employees:
         - 
           name: Bob
           role: Developer
@@ -167,7 +167,7 @@ indented:
           role: Architect
     - 
       name: Marketing
-      employees: 
+      employees:
         - 
           name: Charlie
           role: Manager
@@ -182,7 +182,7 @@ indented:
           [4, 5, 6]
         ]
       };
-      final expected = '''matrix: 
+      final expected = '''matrix:
   - 
     - 1
     - 2

--- a/slang/test/unit/utils/yaml_writer_test.dart
+++ b/slang/test/unit/utils/yaml_writer_test.dart
@@ -107,9 +107,9 @@ indented:
         'fruits': ['apple', 'banana', 'cherry'],
       };
       final expected = '''fruits:
-  - apple
-  - banana
-  - cherry
+- apple
+- banana
+- cherry
 ''';
       expect(convertToYaml(input), equals(expected));
     });
@@ -122,12 +122,10 @@ indented:
         ]
       };
       final expected = '''contacts:
-  - 
-    type: email
-    value: john@example.com
-  - 
-    type: phone
-    value: 555-1234
+- type: email
+  value: john@example.com
+- type: phone
+  value: 555-1234
 ''';
       expect(convertToYaml(input), equals(expected));
     });
@@ -156,21 +154,16 @@ indented:
       final expected = '''company:
   name: Acme Inc
   departments:
-    - 
-      name: Engineering
-      employees:
-        - 
-          name: Bob
-          role: Developer
-        - 
-          name: Alice
-          role: Architect
-    - 
-      name: Marketing
-      employees:
-        - 
-          name: Charlie
-          role: Manager
+  - name: Engineering
+    employees:
+    - name: Bob
+      role: Developer
+    - name: Alice
+      role: Architect
+  - name: Marketing
+    employees:
+    - name: Charlie
+      role: Manager
 ''';
       expect(convertToYaml(input), equals(expected));
     });
@@ -183,14 +176,14 @@ indented:
         ]
       };
       final expected = '''matrix:
-  - 
-    - 1
-    - 2
-    - 3
-  - 
-    - 4
-    - 5
-    - 6
+-
+  - 1
+  - 2
+  - 3
+-
+  - 4
+  - 5
+  - 6
 ''';
       expect(convertToYaml(input), equals(expected));
     });


### PR DESCRIPTION
Following up on https://github.com/slang-i18n/slang/pull/299#issuecomment-2898605266.

I want to integrate Weblate to make submitting translations easier for my contributors, but when using it, Weblate and slang fight over how the yaml files should be formatted, leading to PRs looking like this:
<img width="929" height="577" alt="PR with lots of whitespace formatting changes in yaml files" src="https://github.com/user-attachments/assets/00a6206c-1074-4b8b-af4a-9921fcab6db3" />

***

Weblate was also wrapping lines that got too long, but I can probably just disable this in the Weblate settings. I haven't added line wrapping in this PR.
<img width="884" height="176" alt="image" src="https://github.com/user-attachments/assets/fa79b521-2f6f-4339-ba11-226cc8cc5b4f" />

