### PR TITLE
tweak: format base locale with `slang normalize`

### DIFF
--- a/slang/README.md
+++ b/slang/README.md
@@ -1822,6 +1822,8 @@ dart run slang edit <type> <params...>
 To keep the order of the keys consistent, you can normalize the translations.
 They will follow the same order as the base locale.
 
+As a side effect, this command also reformats the translation file/files.
+
 ```sh
 dart run slang normalize [--locale=fr-FR]
 ```

--- a/slang/lib/src/runner/normalize.dart
+++ b/slang/lib/src/runner/normalize.dart
@@ -11,6 +11,8 @@ import 'package:slang/src/utils/log.dart' as log;
 const _supportedFiles = [FileType.json, FileType.yaml];
 
 /// Normalizes the translation files according to the base locale.
+///
+/// As a side effect, this command also reformats the translation file/files.
 Future<void> runNormalize({
   required SlangFileCollection fileCollection,
   required List<String> arguments,
@@ -40,10 +42,6 @@ Future<void> runNormalize({
     log.info('Target: all locales');
 
     for (final locale in translationMap.getLocales()) {
-      if (locale == fileCollection.config.baseLocale) {
-        continue;
-      }
-
       await _normalizeLocale(
         fileCollection: fileCollection,
         locale: locale,


### PR DESCRIPTION
Trivial patch for https://github.com/slang-i18n/slang/pull/343#issuecomment-3768906064

I'm happy to change/remove the doc comment I added if you want