### PR TITLE
feat: add Portuguese plural resolver

### DIFF
--- a/slang/lib/src/api/plural_resolver_map.dart
+++ b/slang/lib/src/api/plural_resolver_map.dart
@@ -202,6 +202,17 @@ final Map<String, _Resolvers> _resolverMap = {
     },
     ordinal: (n, {zero, one, two, few, many, other}) => other!,
   ),
+  // Portuguese
+  'pt': _Resolvers(
+    cardinal: (n, {zero, one, two, few, many, other}) {
+      final i = n.toInt();
+
+      if (i == 0 || i == 1) return one ?? other!;
+
+      return other!;
+    },
+    ordinal: (n, {zero, one, two, few, many, other}) => other!,
+  ),
   // Russian
   'ru': _Resolvers(
     cardinal: (n, {zero, one, two, few, many, other}) {


### PR DESCRIPTION
Adds the `pt` (Portuguese) entry to the built-in CLDR plural resolver map.

Previously, apps using `pt` / `pt-BR` / `pt-PT` with plurals hit:
`Resolver for <lang = pt> not specified! Please configure it via
LocaleSettings.setPluralResolver. A fallback is used now.`

Uses the CLDR `pt` cardinal rule `i = 0..1` (integers 0, 1 and decimals
`0.0~1.5` → `one`; everything else → `other`). Ordinal is always `other`.
Compact/scientific `many` category is omitted, consistent with existing
`it` resolver precedent.

- [x] CLDR data verified from unicode-org/cldr-json
- [x] `dart analyze` — no issues
- [x] `dart test` — all 465 tests pass