### PR TITLE
feat: add Hebrew plural resolver

### DIFF
--- a/slang/lib/src/api/plural_resolver_map.dart
+++ b/slang/lib/src/api/plural_resolver_map.dart
@@ -146,6 +146,24 @@ final Map<String, _Resolvers> _resolverMap = {
       return other!;
     },
   ),
+  // Hebrew
+  'he': _Resolvers(
+    cardinal: (n, {zero, one, two, few, many, other}) {
+      final i = n.toInt();
+      final v = i == n ? 0 : n.toString().split('.')[1].length;
+
+      if ((i == 1 && v == 0) || (i == 0 && v != 0)) {
+        return one ?? other!;
+      }
+      if (i == 2 && v == 0) {
+        return two ?? other!;
+      }
+      return other!;
+    },
+    ordinal: (n, {zero, one, two, few, many, other}) {
+      return other!;
+    },
+  ),
   // Italian
   'it': _Resolvers(
     cardinal: (n, {zero, one, two, few, many, other}) {

--- a/slang/test/unit/api/pluralization_test.dart
+++ b/slang/test/unit/api/pluralization_test.dart
@@ -1,0 +1,53 @@
+import 'package:slang/slang.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Hebrew plural resolver', () {
+    final cardinal = PluralResolvers.cardinal('he');
+    final ordinal = PluralResolvers.ordinal('he');
+
+    String resolveCardinal(num n) => cardinal(
+          n,
+          one: 'one',
+          two: 'two',
+          other: 'other',
+        );
+
+    String resolveOrdinal(num n) => ordinal(
+          n,
+          one: 'one',
+          two: 'two',
+          other: 'other',
+        );
+
+    test('selects cardinal forms according to CLDR', () {
+      expect(resolveCardinal(0), 'other');
+      expect(resolveCardinal(0.5), 'one');
+      expect(resolveCardinal(1), 'one');
+      expect(resolveCardinal(1.5), 'other');
+      expect(resolveCardinal(2), 'two');
+      expect(resolveCardinal(2.5), 'other');
+      expect(resolveCardinal(3), 'other');
+      expect(resolveCardinal(10), 'other');
+    });
+
+    test('allows Hebrew translations to omit the number for one and two', () {
+      String minutes(num n) => cardinal(
+            n,
+            one: 'דקה',
+            two: 'שתי דקות',
+            other: '$n דקות',
+          );
+
+      expect(minutes(1), 'דקה');
+      expect(minutes(2), 'שתי דקות');
+      expect(minutes(3), '3 דקות');
+    });
+
+    test('always selects other for ordinals', () {
+      for (final n in [0, 1, 2, 3, 10, 21]) {
+        expect(resolveOrdinal(n), 'other');
+      }
+    });
+  });
+}

--- a/slang/test/unit/api/pluralization_test.dart
+++ b/slang/test/unit/api/pluralization_test.dart
@@ -38,10 +38,19 @@ void main() {
             two: 'שתי דקות',
             other: '$n דקות',
           );
+      String days(num n) => cardinal(
+            n,
+            one: 'יום',
+            two: 'יומיים',
+            other: '$n ימים',
+          );
 
       expect(minutes(1), 'דקה');
       expect(minutes(2), 'שתי דקות');
       expect(minutes(3), '3 דקות');
+      expect(days(1), 'יום');
+      expect(days(2), 'יומיים');
+      expect(days(3), '3 ימים');
     });
 
     test('always selects other for ordinals', () {


### PR DESCRIPTION
## Summary

- add a built-in Hebrew cardinal plural resolver based on Unicode CLDR
- support the `one`, `two`, and `other` categories, including Hebrew fractional handling
- use `other` for Hebrew ordinals
- cover category selection and natural Hebrew unit forms in tests

## Validation

- `dart test`
- `dart analyze`